### PR TITLE
Locale: Add interpolation and pluralization support

### DIFF
--- a/locale/demo/demo.view.tree
+++ b/locale/demo/demo.view.tree
@@ -1,0 +1,35 @@
+$mol_locale_demo $mol_demo_small
+	title @ \Locale demo
+	sub /
+		<= Language $mol_select
+			Filter null
+			value?lang <=> language?lang \en
+			dictionary <= languages *
+				en \English
+				ru \Русский
+				cs \Chezh
+		<= header $mol_paragraph title @ \ %{title} :: %{language}
+		<= number $mol_number
+			value?val <=> count?val 26
+		<= exmaple $mol_view
+			style *
+				flex-direction \column
+			sub /
+				<= i_have_foxes @ \I have %{count} fox |||| I have %{count} foxes
+				<= sep_foxes $mol_local_demo_separator
+				<= List $mol_list
+					rows <= item_rows /$mol_locale_demo_row
+				<= sep_rows $mol_local_demo_separator
+				<= total_rows @ \Total: %{item_rows} row |||| Total: %{item_rows} rows
+	Row!index $mol_locale_demo_row
+		index?val <= identity!index 0
+
+$mol_locale_demo_row $mol_view
+	index?val 0
+	style *
+		^
+		background <= getColor \
+	sub /
+		<= text @ \I have %{index} fox |||| I have %{index} foxes
+
+$mol_local_demo_separator $mol_view

--- a/locale/demo/demo.view.tree.css
+++ b/locale/demo/demo.view.tree.css
@@ -1,0 +1,15 @@
+[mol_locale_demo] {
+	flex-direction: column;
+	flex-wrap: nowrap;
+}
+
+[mol_locale_demo_row] {
+	color: white;
+	padding: 2px 10px;
+}
+
+[mol_local_demo_separator] {
+	width: 100%;
+	height: 1em;
+	border-top: 1px solid black;
+}

--- a/locale/demo/demo.view.tree.locale=cs.json
+++ b/locale/demo/demo.view.tree.locale=cs.json
@@ -1,0 +1,6 @@
+{
+	"$mol_locale_demo_title": "Ukázka lokalizace",
+	"$mol_locale_demo_i_have_foxes": "Mám %{count} lišku |||| Mám %{count} lišky |||| Mám %{count} lišek",
+	"$mol_locale_demo_total_rows": "Celkem: %{item_rows} řádek |||| Celkem: %{item_rows} řádky |||| Celkem: %{item_rows} řádků",
+	"$mol_locale_demo_row_text": "Mám %{index} lišku |||| Mám %{index} lišky |||| Mám %{index} lišek"
+}

--- a/locale/demo/demo.view.tree.locale=en.json
+++ b/locale/demo/demo.view.tree.locale=en.json
@@ -1,0 +1,6 @@
+{
+	"$mol_locale_demo_title": "Locale demo",
+	"$mol_locale_demo_i_have_foxes": "I have %{count} fox |||| I have %{count} foxes",
+	"$mol_locale_demo_total_rows": "Total: %{item_rows} row |||| Total: %{item_rows} rows",
+	"$mol_locale_demo_row_text": "I have %{index} fox |||| I have %{index} foxes"
+}

--- a/locale/demo/demo.view.tree.locale=ru.json
+++ b/locale/demo/demo.view.tree.locale=ru.json
@@ -1,0 +1,6 @@
+{
+	"$mol_locale_demo_title": "Демо локализации",
+	"$mol_locale_demo_i_have_foxes": "У меня %{count} лисица |||| У меня %{count} лисицы |||| У меня %{count} лисиц",
+	"$mol_locale_demo_total_rows": "Всего: %{item_rows} строка |||| Всего: %{item_rows} строки |||| Всего: %{item_rows} строк",
+	"$mol_locale_demo_row_text": "У меня %{index} лисица |||| У меня %{index} лисицы |||| У меня %{index} лисиц"
+}

--- a/locale/demo/demo.view.tree.ts
+++ b/locale/demo/demo.view.tree.ts
@@ -1,0 +1,41 @@
+namespace $.$$ {
+	export class $mol_locale_demo extends $.$mol_locale_demo {
+		language( lang?: any ) {
+			if ( lang !== undefined ) return $mol_locale.lang( lang )
+			return $mol_locale.lang()
+		}
+
+
+		@ $mol_mem
+		item_rows() {
+			const count = this.count();
+			return Array.from( { length: count }, ( _, index ) => this.Row(index))
+		}
+
+		identity( val: any ) {
+			return val;
+		}
+	}
+
+	export class $mol_locale_demo_row extends $.$mol_locale_demo_row {
+
+		@ $mol_mem
+		getColor() {
+			const palette = [
+				"#cdc77b",
+				"#9b008b",
+				"#556b2f",
+				"#ff8c00",
+				"#9932cc",
+				"#8b0000",
+				"#e9967a",
+				"#8fbc8f",
+				"#ffd700",
+				"#daa520" ];
+			const plural_rule_fn = $mol_locale.get_plural_rule( $mol_locale.lang() ) || ( (x) => 0 );
+			const index = this.index()
+			return '' + palette[ plural_rule_fn(index) ]
+		}
+	}
+
+}

--- a/locale/demo/index.html
+++ b/locale/demo/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html style=" height: 100% ">
+
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
+
+	<style>
+		body {
+			height: 100%;
+			margin : 0;
+			font: 18px/1.2 'Helvetica Neue', Helvetica, Arial, sans-serif;
+			background: #f5f5f5;
+			color: #4d4d4d;
+		}
+	</style>
+
+	<div mol_view_root="$mol_locale_demo"></div>
+	<script src="web.js" charset="utf-8"></script>

--- a/locale/locale.ts
+++ b/locale/locale.ts
@@ -1,11 +1,104 @@
 namespace $ {
-	
+
 	export interface $mol_locale_dict {
 		[ key : string ] : string
 	}
-	
+
+	export type $mol_locale_plural_rule = ( n: number ) => number
+
+	export interface $mol_locale_plural_dict {
+		[ locale: string ]: $mol_locale_plural_rule
+	}
+
+	export interface $mol_locale_plural_type_to_language {
+		[ locale: string ]: string[]
+	}
+
+	export interface $mol_locale_tranform_param	 {
+		key: string,
+		/// Options for interpolating in %{...} pattern
+		params?: any,
+		/// Count value for pluralization. Override other interpolated option in "%{...}"
+		count?: number
+	}
+
 	export class $mol_locale extends $mol_object {
-		
+
+		static interpolateRegExp = /%\{\s*(.*?)\s*\}/g // %{ }
+		static plural_delimiter = /\|\|\|\|\n?/g;
+		static plural_count_indicator = /\s*is\s+plural/;
+
+		static russian_plural_groups = ( n: number ) => {
+			var lastTwo = n % 100;
+			var end = lastTwo % 10;
+			if( lastTwo !== 11 && end === 1 ) {
+				return 0;
+			}
+			if( 2 <= end && end <= 4 && !( lastTwo >= 12 && lastTwo <= 14 ) ) {
+				return 1;
+			}
+			return 2;
+		}
+
+		// See for actual rules: https://github.com/airbnb/polyglot.js/blob/master/index.js#L48
+		static plural_rules: $mol_locale_plural_dict = {
+			arabic: function( n: number ) {
+				// http://www.arabeyes.org/Plural_Forms
+				if( n < 3 ) { return n; }
+				var lastTwo = n % 100;
+				if( lastTwo >= 3 && lastTwo <= 10 ) return 3;
+				return lastTwo >= 11 ? 4 : 5;
+			},
+			bosnian_serbian: $mol_locale.russian_plural_groups,
+			chinese: function(n) { return 0; },
+			croatian: $mol_locale.russian_plural_groups,
+			french: function( n: number ) { return n >= 2 ? 1 : 0; },
+			german: function( n: number ) { return n !== 1 ? 1 : 0; },
+			russian: $mol_locale.russian_plural_groups,
+			lithuanian: function( n: number ) {
+				if( n % 10 === 1 && n % 100 !== 11 ) { return 0; }
+				return n % 10 >= 2 && n % 10 <= 9 && ( n % 100 < 11 || n % 100 > 19 ) ? 1 : 2;
+			},
+			czech: function( n: number ) {
+				if( n === 1 ) { return 0; }
+				return ( n >= 2 && n <= 4 ) ? 1 : 2;
+			},
+			polish: function( n: number ) {
+				if( n === 1 ) { return 0; }
+				var end = n % 10;
+				return 2 <= end && end <= 4 && ( n % 100 < 10 || n % 100 >= 20 ) ? 1 : 2;
+			},
+			icelandic: function( n: number ) { return ( n % 10 !== 1 || n % 100 === 11 ) ? 1 : 0; },
+			slovenian: function( n: number ) {
+				var lastTwo = n % 100;
+				if( lastTwo === 1 ) {
+					return 0;
+				}
+				if( lastTwo === 2 ) {
+					return 1;
+				}
+				if( lastTwo === 3 || lastTwo === 4 ) {
+					return 2;
+				}
+				return 3;
+			}
+		}
+
+		static plural_type_to_languages: $mol_locale_plural_type_to_language = {
+			arabic: [ 'ar' ],
+			bosnian_serbian: [ 'bs-Latn-BA', 'bs-Cyrl-BA', 'srl-RS', 'sr-RS' ],
+			chinese: [ 'id', 'id-ID', 'ja', 'ko', 'ko-KR', 'lo', 'ms', 'th', 'th-TH', 'zh' ],
+			croatian: [ 'hr', 'hr-HR' ],
+			german: [ 'fa', 'da', 'de', 'en', 'es', 'fi', 'el', 'he', 'hi-IN', 'hu', 'hu-HU', 'it', 'nl', 'no', 'pt', 'sv', 'tr' ],
+			french: [ 'fr', 'tl', 'pt-br' ],
+			russian: [ 'ru', 'ru-RU' ],
+			lithuanian: [ 'lt' ],
+			czech: [ 'cs', 'cs-CZ', 'sk' ],
+			polish: [ 'pl' ],
+			icelandic: [ 'is' ],
+			slovenian: [ 'sl-SL' ]
+		};
+
 		@ $mol_mem
 		static lang_default() {
 			return 'en'
@@ -34,19 +127,86 @@ namespace $ {
 				return this.source( def )
 			}
 		}
-		
-		@ $mol_mem_key
-		static text( key : string ) {
 
-			for( let lang of [ this.lang() , 'en' ] ) {
-				
+		static get_plural_rule( lang: string ) {
+			const rules = this.plural_type_to_languages
+			for( const rule in rules ) {
+				if( rules[ rule ].includes( lang ) )
+					return this.plural_rules[ rule ] || null
+			}
+		}
+
+		/**
+		 * Translate, interpolate and pluralizate
+		 */
+		@ $mol_mem_key
+		static t( { key, params, count }: $mol_locale_tranform_param) {
+			let {lang, text} = this._text( key )
+
+			let plural_count_var_value
+			let first_var_value: any
+			if( params ) {
+				// Interpolate text
+				text = text.replace( this.interpolateRegExp, ( expression, argument ) => {
+					let use_this_var_as_plural = false
+					let method = argument.replace( this.plural_count_indicator, '' )
+					if ( method != argument ) use_this_var_as_plural = true
+					method = params[ method ]
+					const type = typeof method
+					let value;
+					if( type === 'function' ) {
+						value = method.call(params)
+					} else if (type == 'string' || type == 'number' || type == 'boolean') {
+						value = method
+					} else {
+						value = expression
+					}
+					if( Array.isArray( value )) value = value.length
+					if( use_this_var_as_plural ) plural_count_var_value = value
+					if (first_var_value === undefined) first_var_value = value
+					return '' + value
+				} )
+			}
+
+			// Pluralization ||||
+			const texts = text.split( this.plural_delimiter );
+			if( texts.length == 1 ) return texts[ 0 ]
+
+			const plural_count_value = count !== undefined
+				? count
+				: plural_count_var_value !== undefined
+					? plural_count_var_value
+					: first_var_value
+			const plural_rule = this.get_plural_rule(lang)
+			if( !plural_rule ) {
+				this.warn_log( `Plural rule not found for language: "${ lang }"` )
+				return `<${ key }>`
+			}
+			const plural_count = plural_rule( plural_count_value || 0 )
+			let result_text = texts[ plural_count ]
+			if( result_text === undefined ) {
+				const warn = `Plural form #${ plural_count } not found for "${ lang }": ${ key }`
+				this.warn_log( warn )
+				return `<${ warn }>`
+			}
+			return result_text
+
+			return text;
+		}
+
+		@$mol_mem_key
+		static _text( key: string ) {
+			for( let lang of [ this.lang(), 'en' ] ) {
 				const text = this.texts( lang )[ key ]
-				if( text ) return text
+				if( text ) return { text, lang }
 
 				this.warn( key )
 			}
-						
-			return `<${ key }>`
+			return { text: `<${ key }>`, lang: this.lang() }
+		}
+
+		static text( key : string ) {
+			return this._text(key).text
 		}
 		
 		@ $mol_mem_key
@@ -54,7 +214,11 @@ namespace $ {
 			console.warn( `Not translated to "${ this.lang() }": ${ key }` )
 			return null
 		}
-		
+
+		@$mol_mem_key
+		static warn_log ( msg: string ) {
+			console.warn( msg )
+			return null
+		}
 	}
-	
 }

--- a/locale/readme.md
+++ b/locale/readme.md
@@ -1,0 +1,49 @@
+# $mol_locale
+
+Simple solution for translation, interpolation and pluralization.
+
+###### Translation ######
+
+```tree
+	text @ \Hello
+```
+
+en.json file automatically will be generated as *.tree.locale=cs.json `./-view.tree` directory. You need to copy it to component's directory and rename to target language and translate it. Method `$mol_locale.lang(language)` can be used for changing language.
+
+###### Interpolation & pluralization ######
+
+* Use `||||` as delimiter for plural forms.
+* To interpolate use `%{ foo }` markup.
+* Add to option suffix ` is plural` if there are more than one options for interpolating, e.g `%{ foo is plural }`. Otherwise 1st option will be used.
+* Option for interpolating you can use: array (to get count of items); getter function; scalar string or number or boolean.
+
+Examples:
+
+```tree
+$mol_locale_demo_row $mol_view
+	index?val 0
+	sub /
+		<= text @ \I have %{index} fox |||| I have %{index} foxes
+```
+
+When more than one interpolated options: 
+
+```
+$mol_locale_demo $mol_demo_small
+	title @ \Some Book
+	count 1
+	sub /
+		<= test $mol_paragraph title @ \ %{title} - %{count is plural} page |||| %{title} - %{count} pages
+```
+
+Example of usage in code
+
+```ts
+title() {
+	return this.$.$mol_locale.t({
+		// "$mol_locale_demo_total_rows": "Total: %{items} row |||| Total: %{items} rows",
+		key: '$mol_locale_demo_test',
+		params: {items: 70}
+	})
+}
+```

--- a/view/tree2/ts/locale.ts
+++ b/view/tree2/ts/locale.ts
@@ -1,9 +1,9 @@
 namespace $ {
 	export function $mol_view_tree2_ts_locale(operator: $mol_tree2, context: $mol_view_tree2_context) {
 		return [ operator.struct('line', [
-			operator.data('this.$.$mol_locale.text( \''),
+			operator.data('this.$.$mol_locale.t( {key: \''),
 			context.locale(operator),
-			operator.data('\' )'),
+			operator.data('\', params: this})'),
 		]) ]
 	}
 }

--- a/view/tree2/ts/method/method.ts
+++ b/view/tree2/ts/method/method.ts
@@ -10,12 +10,13 @@ namespace $ {
 		const operator = src.kids.length === 1 ? src.kids[0] : undefined
 		const type = operator?.type
 		const is_class = type && type[0] === '$'
+		const is_locale = type == '@'
 		const is_delegate = type === '<=' || type === '<=>'
 
 		let need_cache = false
 		if (is_delegate) need_cache = false
 		else if (next !== undefined) need_cache = true
-		else if (is_class) need_cache = true
+		else if (is_class || is_locale) need_cache = true
 
 		const sub: $mol_tree2[] = this.$mol_view_tree2_ts_comment_doc(src)
 


### PR DESCRIPTION
Hi, during learning how this framework works I tried to add interpolation support in view.tree by `@ \`.

This patch adds support pluralization and interpolation in poliglot.js style - `%{...}`, `||||`. 

Interpolation should reduce boilerplate code, no need to override methods for text manipulation.
Probably good to implement similar feature for text data e.g ` foo \Some %{text}` too

You can check readme and demo files for examples.

This is work in progress. Please give me your opinion about it and what can be improved or changed to follow your style guide.