### PR TITLE
Fix commonjs detector for minified files

### DIFF
--- a/build/build.node.ts
+++ b/build/build.node.ts
@@ -860,7 +860,7 @@ namespace $ {
 					try {
 						const content = this.js_content( src.path() )
 						
-						const isCommonJs = /module\.exports|\bexports\.\w+\s*=/.test( content.text )
+						const isCommonJs = /typeof +exports|module\.exports|\bexports\.\w+\s*=/.test( content.text )
 					
 						if( isCommonJs ) {
 							concater.add( `\nvar $node = $node || {}\nvoid function( module ) { var exports = module.${''}exports = this; function require( id ) { return $node[ id.replace( /^.\\// , "` + src.parent().relate( this.root().resolve( 'node_modules' ) ) + `/" ) ] }; \n`, '-' )


### PR DESCRIPTION
This fixes issue in https://github.com/hyoo-ru/mam/issues/21#issuecomment-869559318

Minified IIFE commonjs files have no `module.exports` or `exports.`.
But there is check for "exports", I think it is ok to use it for detecting commonjs, **but might be false detect** 
To reproduce, bug, change lib/ramda to next 

```
export let $lib_ramda = require( 'ramda/dist/ramda.min.js' ) as typeof import( 'ramda' )
```

and try to use any function  somewhere by `const { invertObj } = $lib_ramda;`

minified file `dist/ramda.min.js` starts with:
```
!function(t,n){"object"==typeof exports&&"undefined"!=typeof module?n(exports):"function"==typeof define&&define.amd?define(["exports"],n):n((t=t||self).R={})}(this,function(t){"use strict";function a(t){return null!=t&&"object"==typeof t&&!
```

This files is created by rollup, similar IIFE is for modules like redux (rollup) too.

Other rollup's minified lib might have same issue