### PR TITLE
$mol_scroll: Enlarge scrollbar when mouse is close to it

### DIFF
--- a/frame/frame.view.tree
+++ b/frame/frame.view.tree
@@ -1,6 +1,7 @@
 $mol_frame $mol_embed_native
 	dom_name \iframe
 	attr *
+		^
 		data null
 		type null
 		src <= uri?val \

--- a/scroll/scroll.view.css.ts
+++ b/scroll/scroll.view.css.ts
@@ -25,21 +25,21 @@ namespace $.$$ {
 		webkitOverflowScrolling: 'touch',
 		contain: 'content',
 
-		'[enlarge-scrollbar-x]::-webkit-scrollbar' {
+		'[enlarge-scrollbar-x]::-webkit-scrollbar': {
 			width: rem( .75 ),
 		},
 
-		'[enlarge-scrollbar-x]::-webkit-scrollbar-track' {
+		'[enlarge-scrollbar-x]::-webkit-scrollbar-track': {
 			background: {
 				color: 'rgba(1,1,1, 0.025)',
 			},
 		},
 
-		'[enlarge-scrollbar-y]::-webkit-scrollbar' {
+		'[enlarge-scrollbar-y]::-webkit-scrollbar': {
 			height: rem( .75 ),
 		},
 
-		'[enlarge-scrollbar-y]::-webkit-scrollbar-track' {
+		'[enlarge-scrollbar-y]::-webkit-scrollbar-track': {
 			background: {
 				color: 'rgba(1,1,1, 0.025)',
 			},

--- a/scroll/scroll.view.css.ts
+++ b/scroll/scroll.view.css.ts
@@ -25,6 +25,26 @@ namespace $.$$ {
 		webkitOverflowScrolling: 'touch',
 		contain: 'content',
 
+		'[enlarge-scrollbar-x]::-webkit-scrollbar' {
+			width: rem( .75 ),
+		},
+
+		'[enlarge-scrollbar-x]::-webkit-scrollbar-track' {
+			background: {
+				color: 'rgba(1,1,1, 0.025)',
+			},
+		},
+
+		'[enlarge-scrollbar-y]::-webkit-scrollbar' {
+			height: rem( .75 ),
+		},
+
+		'[enlarge-scrollbar-y]::-webkit-scrollbar-track' {
+			background: {
+				color: 'rgba(1,1,1, 0.025)',
+			},
+		},
+
 		'>': {
 			$mol_view: {
 				transform: 'translateZ(0)', // enforce gpu scroll in all agents

--- a/scroll/scroll.view.tree
+++ b/scroll/scroll.view.tree
@@ -10,5 +10,6 @@ $mol_scroll $mol_view
 		mousemove?event <=> event_move?event null
 		mouseleave?event <=> event_mouseleave?event null
 	attr *
+		^
 		enlarge-scrollbar-x <= is_enlarged_x?val false
 		enlarge-scrollbar-y <= is_enlarged_y?val false

--- a/scroll/scroll.view.tree
+++ b/scroll/scroll.view.tree
@@ -7,3 +7,8 @@ $mol_scroll $mol_view
 	event *
 		^
 		scroll?event <=> event_scroll?event null
+		mousemove?event <=> event_move?event null
+		mouseleave?event <=> event_mouseleave?event null
+	attr *
+		enlarge-scrollbar-x <= is_enlarged_x?val false
+		enlarge-scrollbar-y <= is_enlarged_y?val false

--- a/scroll/scroll.view.ts
+++ b/scroll/scroll.view.ts
@@ -36,7 +36,23 @@ namespace $.$$ {
 		minimal_width() {
 			return this.$.$mol_print.active() ? null! : 0
 		}
-		
+
+		event_mouseleave( event: MouseEvent ) {
+			this.is_enlarged_x( false )
+			this.is_enlarged_y( false )
+		}
+
+		event_move( event: MouseEvent ) {
+			const el = this.dom_node()
+			const rect = el.getBoundingClientRect()
+			const x = event.clientX - rect.left
+			const y = event.clientY - rect.top
+
+			const enlargeX = rect.width - x < 30
+			const enlargeY = rect.height - y < 30
+			this.is_enlarged_x( enlargeX )
+			this.is_enlarged_y( enlargeY )
+		}
 	}
 
 }


### PR DESCRIPTION
**It is hard to drag scrollbar on desktop**. Width/height of scrollbar is just 0.25rem.
This PR enlarge width/height by x3 and set background to rgba 1,1,1, 0.25 if mouse is moved close to scroll bar (30px);
Sadly animation for width/heights of scrollbar does not supported.

Default scrollbar is without changes:
![regular-x](https://user-images.githubusercontent.com/213405/166076086-fe95b58b-f6a9-4615-8bcf-b6cddd205a0e.png)

When mouse is close to vertical scrollbar:
![regular-x-enlg](https://user-images.githubusercontent.com/213405/166076088-c28f8c81-131b-4dad-b1ab-36512e242236.png)
