### PR TITLE
Refactor event handling 

### DIFF
--- a/dom/render/events/events.ts
+++ b/dom/render/events/events.ts
@@ -2,20 +2,12 @@ namespace $ {
 	
 	export function $mol_dom_render_events (
 		el : Element ,
-		events : { [ key : string ] : ( event : Event )=> any }
+		events : { [ key : string ] : ( event : Event )=> any },
+		passive = false
 	) {
 		for( let name in events ) {
-			el.addEventListener( name , events[ name ] , { passive : false } as any )
+			el.addEventListener( name , events[ name ] , { passive } )
 		}
 	}
-	
-	export function $mol_dom_render_events_async (
-		el : Element ,
-		events : { [ key : string ] : ( event : Event )=> any }
-	) {
-		for( let name in events ) {
-			el.addEventListener( name , events[ name ] , { passive : true } as any )
-		}
-	}
-	
+
 }

--- a/view/view/view.ts
+++ b/view/view/view.ts
@@ -172,7 +172,7 @@ namespace $ {
 			$mol_dom_render_attributes( node , this.attr_static() )
 			
 			const events = $mol_wire_async( this.event() )
-			$mol_dom_render_events_async(node, events)
+			$mol_dom_render_events(node, events)
 
 			return node
 		}

--- a/view/view/view.ts
+++ b/view/view/view.ts
@@ -172,13 +172,7 @@ namespace $ {
 			$mol_dom_render_attributes( node , this.attr_static() )
 			
 			const events = $mol_wire_async( this.event() )
-			for( let event_name in events ) {
-				node.addEventListener(
-					event_name ,
-					events[ event_name ] ,
-					{ passive : false } as any ,
-				)
-			}
+			$mol_dom_render_events_async(node, events)
 
 			return node
 		}


### PR DESCRIPTION
- remove `$mol_dom_render_events_async`: it's not used anywhere and mostly duplicates `$mol_dom_render_events`
- add `passive` parameter to `$mol_dom_render_events`
- use `$mol_dom_render_events` to attach event handlers to a node in `$mol_view#dom_node`