### PR TITLE
"catched" variable name typo in catch.ts

### DIFF
--- a/fail/catch/catch.ts
+++ b/fail/catch/catch.ts
@@ -1,14 +1,14 @@
 namespace $ {
 
-	const cacthed = new WeakMap< any , boolean >()
+	const catched = new WeakMap< any , boolean >()
 
 	export function $mol_fail_catch( error: unknown ) {
 		
 		if( typeof error !== 'object' ) return false
 		if( error instanceof Promise ) $mol_fail_hidden( error )
-		if( cacthed.get( error ) ) return false
+		if( catched.get( error ) ) return false
 		
-		cacthed.set( error , true )
+		catched.set( error , true )
 		return true
 		
 	}


### PR DESCRIPTION
variable name "cacthed" now corrected to "catched"