### PR TITLE
Кнопка исходников демо пересена на колонку с демо

### DIFF
--- a/app/demo/demo.view.tree
+++ b/app/demo/demo.view.tree
@@ -64,6 +64,9 @@ $mol_app_demo_detail $mol_page
 			hint @ \Readme
 			sub /
 				<= readme_icon $mol_icon_information_outline
+		<= Source_link $mol_link_source
+			uri <= source_link \
+			hint <= source_hint @ \Source code of this demo
 		<= Chat $mol_chat
 			pages => chat_pages
 			seed <= chat_seed \0_0
@@ -89,9 +92,6 @@ $mol_app_demo_readme $mol_page
 	module /string
 	title @ \Readme
 	tools /
-		<= Source_link $mol_link_source
-			uri <= source_link \
-			hint <= source_hint @ \Source code of this demo
 		<= Close $mol_link 
 			hint @ \Close panel
 			sub /


### PR DESCRIPTION
<img width="1452" alt="Снимок экрана 2023-03-11 в 13 08 15" src="https://user-images.githubusercontent.com/32732179/224478364-4dd6782b-8bfa-4f94-aa85-0e055e536ebd.png">


Кнопка перенесена, ссылка не правильно отображается, не разобрался как это сделать, нужна помощь.