### PR TITLE
fix $mol_lights prefers-color-scheme getting

### DIFF
--- a/lights/lights.ts
+++ b/lights/lights.ts
@@ -14,7 +14,7 @@ namespace $ {
 		
 		const arg = parse( this.$mol_state_arg.value( 'mol_lights' ) )
 		
-		const base = false //this.$mol_media.match( '(prefers-color-scheme: light)' )
+		const base = this.$mol_media.match( '(prefers-color-scheme: light)' )
 		
 		if( next === undefined ) {
 			return arg ?? this.$mol_state_local.value< boolean >( '$mol_lights' ) ?? base


### PR DESCRIPTION
https://t.me/mam_mol/124586
Я хочу видеть тему установленную в системе, а не ту которую хочет разработчик. Если какой то элемент в светлой теме багует нужно его исправлять, а не тему переключать) И уж точно не нужно выпускать в прод компонент который не протестили
