### PR TITLE
fix - параметры TS сервера

### DIFF
--- a/build/build.node.ts
+++ b/build/build.node.ts
@@ -351,7 +351,6 @@ namespace $ {
 				
 				{
 					... $node.typescript.sys ,
-					watchDirectory: (()=>{}) as any,
 					writeFile : (path , data )=> {
 						$mol_file.relative( path ).text( data, 'virt' )
 					},

--- a/build/build.node.ts
+++ b/build/build.node.ts
@@ -339,7 +339,7 @@ namespace $ {
 
 			const watchers = new Map< string , ( path : string , kind : number )=> void >()
 			let run = ()=> {}
-
+			
 			var host = $node.typescript.createWatchCompilerHost(
 
 				paths ,
@@ -351,6 +351,9 @@ namespace $ {
 				
 				{
 					... $node.typescript.sys ,
+					watchDirectory: () => { 
+						return { close(){} }
+					},
 					writeFile : (path , data )=> {
 						$mol_file.relative( path ).text( data, 'virt' )
 					},


### PR DESCRIPTION
Фикс ошибки в недрах typescript.js "read 'close' of undefined" после сохранения файлов. Пустой объект в watchDirectory вызывает ошибку.