### PR TITLE
mol_card, rows readonly type

### DIFF
--- a/card/card.view.ts
+++ b/card/card.view.ts
@@ -6,7 +6,7 @@ namespace $.$$ {
 	 */
 	export class $mol_card extends $.$mol_card {
 
-		rows() {
+		rows(): readonly $mol_view[] {
 			return [
 				this.Content() ,
 				... this.status_text() ? [ this.Status() ] : [],


### PR DESCRIPTION
иначе ts ругается на код скомпиленый из подобного tree

```tree
$gd_rad_card $gd_kit_link
	sub /$mol_view
		<= Card $mol_card
			status <= status \success
			rows /$mol_view
				<= Status $mol_view
					minimal_height 30
					sub /
						<= Title $mol_view
							minimal_width 200
							minimal_height 30
							sub /
								<= title \
						<= Tools $mol_view sub /
							<= tools /
```