### PR TITLE
Change *kids* to *children* in error message

### DIFF
--- a/view/tree2/value/value.ts
+++ b/view/tree2/value/value.ts
@@ -16,7 +16,7 @@ namespace $ {
 		}
 
 		if (kids.length !== 0) return this.$mol_fail(
-			err`Kids are not allowed at ${value.span}, use ${example}`
+			err`Children are not allowed at ${value.span}, use ${example}`
 		)
 
 		if (type === 'false' || type === 'true') return value.data(type)


### PR DESCRIPTION
The term `kids` is very misleading, please, let's use a standard term.