### PR TITLE
$mol_text_code: remove font-family inherit

### DIFF
--- a/text/code/code.view.css.ts
+++ b/text/code/code.view.css.ts
@@ -12,12 +12,6 @@ namespace $.$$ {
 		Rows: {
 			padding: $mol_gap.text,
 		},
-
-		Row: {
-			font: {
-				family: 'inherit',
-			},
-		},
 		
 		Copy: {
 			alignSelf: 'flex-start',


### PR DESCRIPTION
С этим изменением починилась разметка для оформления моноширных частей (;; и ``)