### PR TITLE
$mol_compare_deep: fix cyclic reference bug with warmed cache

### DIFF
--- a/compare/deep/deep.test.tsx
+++ b/compare/deep/deep.test.tsx
@@ -75,6 +75,26 @@ namespace $ {
 
 		} ,
 
+		'same POJOs with cyclic reference with cache warmup'() {
+			const obj1 = { test: 1, obj3: null as unknown as Object }
+			const obj1_copy = { test: 1, obj3: null as unknown as Object }
+			const obj2 = { test: 2, obj1 }
+			const obj2_copy = { test: 2, obj1: obj1_copy }
+			const obj3 = { test: 3, obj2 }
+			const obj3_copy = { test: 3, obj2: obj2_copy }
+
+			obj1.obj3 = obj3
+			obj1_copy.obj3 = obj3_copy
+
+			// warmup cache
+			$mol_assert_not( $mol_compare_deep( obj1 , {} ) )
+			$mol_assert_not( $mol_compare_deep( obj2 , {} ) )
+			$mol_assert_not( $mol_compare_deep( obj3 , {} ) )
+
+			$mol_assert_ok( $mol_compare_deep( obj3 , obj3_copy ) )
+
+		} ,
+
 		'Date'() {
 			$mol_assert_ok( $mol_compare_deep( new Date( 12345 ) , new Date( 12345 ) ) )
 			$mol_assert_not( $mol_compare_deep( new Date( 12345 ) , new Date( 12346 ) ) )

--- a/compare/deep/deep.ts
+++ b/compare/deep/deep.ts
@@ -36,10 +36,12 @@ namespace $ {
 
 		} else {
 			
-			left_cache = new WeakMap< any , boolean >([[ right, true ]])
+			left_cache = new WeakMap< any , boolean >()
 			$mol_compare_deep_cache.set( left , left_cache )
 
 		}
+
+		left_cache.set(right, true);
 
 		let result!: boolean
 


### PR DESCRIPTION
Заметил у вас баг в функции $mol_compare_deep: если работать с прогретым кешем, то будет ошибка `RangeError: Maximum call stack size exceeded`.

Тест написал, но не разобрался как его запустить. Но там точно должна воспроизводиться проблема.