### PR TITLE
при существовании вебманифеста не ломаем extension манифест

### DIFF
--- a/build/build.node.ts
+++ b/build/build.node.ts
@@ -1273,15 +1273,19 @@ namespace $ {
 			var target = pack.resolve( `-/manifest.json` )
 			let name = pack.relate( this.root() ).replace( /\//g , '_' )
 
+			const has_webmanifest = pack.resolve( `manifest.webmanifest` ).exists()
+
 			const json = {
 				name ,
 				short_name : name ,
 				description : '' ,
-				id : name ,
-				start_url : '.' ,
-				display : 'standalone' as string ,
-				background_color : '#000000' ,
-				theme_color : '#000000' ,
+				... has_webmanifest ? {} : {
+					id : name ,
+					start_url : '.' ,
+					display : 'standalone' as string ,
+					background_color : '#000000' ,
+					theme_color : '#000000' ,
+				} ,
 			}
 
 			const source = pack.resolve( `manifest.json` )


### PR DESCRIPTION
в прошлый раз это упустил

это не ломает расширение но будут ошибки

<img width="443" height="249" alt="image" src="https://github.com/user-attachments/assets/52e1cde0-fb72-4f54-af21-bcd6820eec8b" />
<img width="1012" height="646" alt="image" src="https://github.com/user-attachments/assets/25d97215-1ebd-401d-a8c9-b2fc9010d29c" />
