### PR TITLE
fix(view/tree2): update expected positions in props test

### DIFF
--- a/view/tree2/class/props.test.ts
+++ b/view/tree2/class/props.test.ts
@@ -127,11 +127,11 @@ namespace $.$$ {
 
 			$mol_assert_fail(
 				() => normalize($, src).input,
-				`Need an equal default values at \`/mol/view/tree2/class/props.test.ts#4:16/5\` vs \`/mol/view/tree2/class/props.test.ts#6:23/11\`
+				`Need an equal default values at \`/mol/view/tree2/class/props.test.ts#4:16/5\` vs \`/mol/view/tree2/class/props.test.ts#6:18/6\`
 <=>
-/mol/view/tree2/class/props.test.ts#6:19/3
+/mol/view/tree2/class/props.test.ts#6:14/3
 click?
-/mol/view/tree2/class/props.test.ts#6:7/11
+/mol/view/tree2/class/props.test.ts#6:7/6
 $mol_button_minor
 /mol/view/tree2/class/props.test.ts#5:12/17
 Clear


### PR DESCRIPTION
`conflicting right bind dupes` fails on master since fdd6248 (`remove deprecated syntax usage`).

That commit rewrote the fixture from `click?event <=> clear?event null` to `click? <=> clear? null`, but the expected error message kept the column numbers of the old, longer tokens.

Every position shifts by exactly 5 characters, the length of the dropped `event`:

| | before | after |
|---|---|---|
| `clear?` | `#6:23/11` | `#6:18/6` |
| `<=>` | `#6:19/3` | `#6:14/3` |
| `click?` | `#6:7/11` | `#6:7/6` |

Verified against the compiler: with the fixture as committed the test fails, with these numbers `mol/view/tree2` passes all 214 tests.

Downstream effect: every MAM project whose CI clones packs fresh from master has had a red build since 12 Aug — the failure surfaces inside the project's own `node.test.js` run, which makes it look like the project's fault.