### PR TITLE
fix(view/selection): notice focus leaving for nothing

### DIFF
--- a/view/selection/selection.web.ts
+++ b/view/selection/selection.web.ts
@@ -12,11 +12,18 @@ namespace $ {
 			
 		}
 		
+		function blur( event: Event ) {
+			$mol_view_selection.focused( $mol_maybe( ( event as FocusEvent ).relatedTarget as HTMLElement ), 'notify' )
+		}
+		
 		function watch( root: Document | ShadowRoot ) {
 			
 			
 			root.removeEventListener( 'focus', focus, true )
 			root.addEventListener( 'focus', focus, true )
+			
+			root.removeEventListener( 'focusout', blur, true )
+			root.addEventListener( 'focusout', blur, true )
 			
 		}
 		


### PR DESCRIPTION
`$mol_view_selection.focused()` is refreshed from a capture listener on `focus`. Clicking empty space moves the document's active element to `<body>` without raising `focus` on anything, so nothing invalidates the cell and it keeps reporting the element that held focus before the click.

Reproduction with `$mol_search`: type into it so the suggestion list opens, then click blank page background. The list stays open, because `suggests_showed` is guarded by `focused()` and that returns a stale `true`. Clicking another focusable element closes it as expected — only the "focus went nowhere" case is missed.

The fix adds a `focusout` capture listener next to the existing `focus` one. `relatedTarget` is the element about to receive focus, and null when none will, which is exactly the value the cell should take.

Checked on a page with two `$mol_search` pickers: before the change `focused()` stayed `true` after an outside click with `document.activeElement` already `BODY`; after it, `focused()` goes `false` and the list closes. Opening and picking a suggestion still work.