### PR TITLE
$mol_schema: поддержка Standard Schema v1

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -9,6 +9,7 @@
 - `.guard(val)` - strict parser.
 - `.cast(val)` - relaxed caster.
 - `.default` - default value for casting.
+- `.~standard` - [Standard Schema v1](https://standardschema.dev/) props.
 
 ## Leaf schemas
 
@@ -82,6 +83,20 @@ if( $my_user_main.check( user ) ) {
 
 ```ts
 const article = $my_article_full.default // default article state
+```
+
+## Standard Schema
+
+Every schema implements [Standard Schema v1](https://standardschema.dev/):
+
+```ts
+const result = MySchema[ '~standard' ].validate( data )
+
+if( result.issues ) {
+	for( const issue of result.issues ) console.error( issue.path, issue.message )
+} else {
+	result.value // typed data
+}
 ```
 
 ## Usage from NPM

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -42,6 +42,11 @@ namespace $ {
 			}
 		}
 		
+		/** [Standard Schema v1](https://standardschema.dev) interop props. */
+		static get [ '~standard' ]() {
+			return $mol_schema_standard_props_of( this )
+		}
+
 		/** Default value which conforms schema. */
 		static default = null as unknown
 		

--- a/schema/schema/schema.meta.tree
+++ b/schema/schema/schema.meta.tree
@@ -1,3 +1,4 @@
+include \/mol/schema/standard
 include \/mol/schema/any
 include \/mol/schema/bigint
 include \/mol/schema/boolean

--- a/schema/standard/standard.test.ts
+++ b/schema/standard/standard.test.ts
@@ -1,0 +1,72 @@
+namespace $.$$ {
+	$mol_test({
+
+		"Standard Schema meta"( $ ) {
+
+			const std = $mol_schema_string[ '~standard' ]
+			$mol_assert_equal( std.version, 1 )
+			$mol_assert_equal( std.vendor, '$mol_schema' )
+
+		},
+
+		"Validate success"( $ ) {
+
+			const res = $mol_schema_string[ '~standard' ].validate( 'foo' ) as $mol_schema_standard_success_result< string >
+			$mol_assert_equal( res.value, 'foo' )
+			$mol_assert_equal( res.issues, undefined )
+
+		},
+
+		"Validate failure"( $ ) {
+
+			const res = $mol_schema_string[ '~standard' ].validate( 123 ) as $mol_schema_standard_failure_result
+			$mol_assert_equal( res.issues.length, 1 )
+			$mol_assert_equal( res.issues[ 0 ].message, 'Wrong type' )
+			$mol_assert_equal( res.issues[ 0 ].path, undefined )
+
+		},
+
+		"Nested issue path of record field"( $ ) {
+
+			const Rec = $mol_schema_record({ name: $mol_schema_string })
+			const res = Rec[ '~standard' ].validate({ name: 123 }) as $mol_schema_standard_failure_result
+
+			$mol_assert_equal( res.issues.length, 1 )
+			$mol_assert_equal( ( res.issues[ 0 ].path as $mol_schema_standard_path_segment[] )[ 0 ].key, 'name' )
+
+		},
+
+		"Nested issue path of list item"( $ ) {
+
+			const List = $mol_schema_list( $mol_schema_string )
+			const res = List[ '~standard' ].validate([ 'foo', 123 ]) as $mol_schema_standard_failure_result
+
+			$mol_assert_equal( res.issues.length, 1 )
+			const path = res.issues[ 0 ].path as $mol_schema_standard_path_segment[]
+			$mol_assert_equal( path.length, 1 )
+			$mol_assert_equal( path[ 0 ].key, 1 )
+
+		},
+
+		"Multiple issues from variants"( $ ) {
+
+			const Some = $mol_schema_some([ $mol_schema_string, $mol_schema_natural ])
+			const res = Some[ '~standard' ].validate( null ) as $mol_schema_standard_failure_result
+
+			$mol_assert_equal( res.issues.length, 2 )
+
+		},
+
+		"Lazy schema delegates validation"( $ ) {
+
+			const Lazy = $mol_schema_lazy( ()=> $mol_schema_string )
+			const ok = Lazy[ '~standard' ].validate( 'foo' ) as $mol_schema_standard_success_result< string >
+			$mol_assert_equal( ok.value, 'foo' )
+
+			const fail = Lazy[ '~standard' ].validate( 123 ) as $mol_schema_standard_failure_result
+			$mol_assert_equal( fail.issues[ 0 ].message, 'Wrong type' )
+
+		},
+
+	})
+}

--- a/schema/standard/standard.ts
+++ b/schema/standard/standard.ts
@@ -1,0 +1,138 @@
+namespace $ {
+
+	/** The path segment interface of the issue. */
+	export interface $mol_schema_standard_path_segment {
+		/** The key representing a path segment. */
+		readonly key: PropertyKey
+	}
+
+	/** The issue interface of the failure output. */
+	export interface $mol_schema_standard_issue {
+		/** The error message of the issue. */
+		readonly message: string
+		/** The path of the issue, if any. */
+		readonly path?: ReadonlyArray< PropertyKey | $mol_schema_standard_path_segment > | undefined
+	}
+
+	/** The result interface if validation succeeds. */
+	export interface $mol_schema_standard_success_result< Output = unknown > {
+		/** The typed output value. */
+		readonly value: Output
+		/** A falsy value for `issues` indicates success. */
+		readonly issues?: undefined
+	}
+
+	/** The result interface if validation fails. */
+	export interface $mol_schema_standard_failure_result {
+		/** The issues of failed validation. */
+		readonly issues: ReadonlyArray< $mol_schema_standard_issue >
+	}
+
+	/** The result type of the validate function. */
+	export type $mol_schema_standard_result< Output = unknown >
+		= $mol_schema_standard_success_result< Output >
+		| $mol_schema_standard_failure_result
+
+	/** The options for the validate function. */
+	export interface $mol_schema_standard_options {
+		/** Explicit support for additional vendor-specific parameters, if needed. */
+		readonly libraryOptions?: Record< string, unknown > | undefined
+	}
+
+	/** The Standard types interface. */
+	export interface $mol_schema_standard_types< Input = unknown, Output = Input > {
+		/** The input type of the schema. */
+		readonly input: Input
+		/** The output type of the schema. */
+		readonly output: Output
+	}
+
+	/** The Standard Typed properties interface. */
+	export interface $mol_schema_standard_typed_props< Input = unknown, Output = Input > {
+		/** The version number of the standard. */
+		readonly version: 1
+		/** The vendor name of the schema library. */
+		readonly vendor: string
+		/** Inferred types associated with the schema. */
+		readonly types?: $mol_schema_standard_types< Input, Output > | undefined
+	}
+
+	/** The Standard Schema properties interface. */
+	export interface $mol_schema_standard_props< Input = unknown, Output = Input >
+		extends $mol_schema_standard_typed_props< Input, Output > {
+
+		/** Validates unknown input values. */
+		readonly validate: (
+			value: unknown,
+			options?: $mol_schema_standard_options | undefined
+		) => $mol_schema_standard_result< Output > | Promise< $mol_schema_standard_result< Output > >
+
+	}
+
+	/** The Standard Typed interface. This is a base type extended by other specs. */
+	export interface $mol_schema_standard_typed< Input = unknown, Output = Input > {
+		/** The Standard properties. */
+		readonly '~standard': $mol_schema_standard_typed_props< Input, Output >
+	}
+
+	/** The Standard Schema interface. */
+	export interface $mol_schema_standard< Input = unknown, Output = Input > {
+		/** The Standard Schema properties. */
+		readonly '~standard': $mol_schema_standard_props< Input, Output >
+	}
+
+	/** Infers the input type of a Standard Schema. */
+	export type $mol_schema_standard_infer_input< Schema extends $mol_schema_standard_typed >
+		= NonNullable< Schema[ '~standard' ][ 'types' ] >[ 'input' ]
+
+	/** Infers the output type of a Standard Schema. */
+	export type $mol_schema_standard_infer_output< Schema extends $mol_schema_standard_typed >
+		= NonNullable< Schema[ '~standard' ][ 'types' ] >[ 'output' ]
+
+	/**
+	 * Converts thrown error to [Standard Schema](https://standardschema.dev) issues.
+	 * Walks through nested `cause.error` and `AggregateError.errors`
+	 * collecting path segments from `field`, `key` and `index`.
+	 */
+	export function $mol_schema_standard_issues(
+		error: any,
+		path: ReadonlyArray< PropertyKey | $mol_schema_standard_path_segment > = [],
+	): ReadonlyArray< $mol_schema_standard_issue > {
+
+		const cause = error?.cause ?? {}
+		const segment = cause.field ?? cause.key ?? cause.index
+		const deep: ReadonlyArray< PropertyKey | $mol_schema_standard_path_segment >
+			= ( segment === undefined ) ? path : [ ...path, { key: segment } ]
+
+		if( Array.isArray( error?.errors ) ) {
+			return ( error.errors as readonly unknown[] )
+				.flatMap( sub => $mol_schema_standard_issues( sub, deep ) )
+		}
+
+		if( cause.error ) return $mol_schema_standard_issues( cause.error, deep )
+
+		const message = String( error?.message ?? error )
+		return [ deep.length ? { message, path: deep } : { message } ]
+
+	}
+
+	/** Builds [Standard Schema v1](https://standardschema.dev) props for a schema class. */
+	export function $mol_schema_standard_props_of<
+		Schema extends typeof $mol_schema_any
+	>( Schema: Schema ): $mol_schema_standard_props< unknown, Schema[ 'default' ] > {
+
+		return {
+			version: 1,
+			vendor: '$mol_schema',
+			validate( value ) {
+				try {
+					return { value: Schema.guard( value ) }
+				} catch( error ) {
+					return { issues: $mol_schema_standard_issues( error ) }
+				}
+			},
+		}
+
+	}
+
+}


### PR DESCRIPTION
Каждая схема $mol_schema_* теперь реализует Standard Schema v1 (https://standardschema.dev/) — единый интерфейс валидации, совместимый с Zod, Valibot, ArkType и др.

### Что сделано

Новый модуль schema/standard:

- Типы спеки v1: $mol_schema_standard_props, _issue, _result, _types, _typed и др.
- $mol_schema_standard_issues() — конвертирует брошенные ошибки в issues: обходит вложенные cause.error и AggregateError.errors, собирает путь из field / key / index
- $mol_schema_standard_props_of() — собирает пропсы ~standard для класса схемы (version: 1, vendor: '$mol_schema', validate)

Базовый класс $mol_schema_any:

- Добавлен статический геттер [ '~standard' ], поэтому все схемы автоматически получают поддержку стандарта без изменений в наследниках

### Прочее:
- Подключение модуля в schema/schema/schema.meta.tree
- Секция «Standard Schema» в README с примером использования
- Тесты: validate для строк, записей, списков, union и рекурсивных схем

### Использование
```ts
const result = MySchema[ '~standard' ].validate( data )

if( result.issues ) {
	for( const issue of result.issues ) console.error( issue.path, issue.message )
} else {
	result.value // типизированные данные
}
```