### PR TITLE
$mol_schema: + issues(value)

### DIFF
--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -41,7 +41,7 @@ namespace $ {
 			return this.check( value )
 		}
 		
-		static _get_error( { issues, path, kind, message }: $mol_schema_issue & { kind?: string }, options: ErrorOptions): Error {
+		static _get_error( { issues, path, kind, message }: $mol_schema_issue & { kind?: string | undefined }, options: ErrorOptions): Error {
 			const last = path.at(-1)
 			if( typeof last === "object" ) message = "Wrong key"
 			else if( typeof last === "number" ) message = "Wrong item"

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -34,7 +34,7 @@ namespace $ {
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
 			const { value: issue } = this.issues_lazy(value).next()
-			if (issue) $mol_fail(new TypeError(issue.message, { cause: { value, schema: this, path: issue.path } }))
+			if( issue ) $mol_fail( new TypeError( issue.message, { cause: { ...issue, value, schema: this } } ) )
 			return value
 		}
 		

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -35,8 +35,8 @@ namespace $ {
 		
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const { value: issue }  = this.issues_lazy( value ).next()
-			if (!issue) return value
+			const { value: issue } = this.issues_lazy( value ).next()
+			if( !issue ) return value
 			return $mol_fail( new TypeError( issue.message, { cause: {
 				value,
 				schema: this,
@@ -77,11 +77,12 @@ namespace $ {
 		}
 
 	}
+
 	type Issue<Value> = Omit< $mol_schema_issue<Value>, 'issues' > & { issues?: Issue<Value>[] }
 	export function $mol_schema_issue_eager< Value >( issue: $mol_schema_issue<Value> ) {
 		const { issues, ...i } = issue
-		if( issues ) Object.defineProperty( i, "issues", {
-			get: $mol_memo.func( () => Array.from( issues, $mol_schema_issue_eager ) )
+		if( issues ) Object.defineProperty( i, 'issues', {
+			get: $mol_memo.func( ()=> Array.from( issues, $mol_schema_issue_eager ) )
 		} )
 		return i as Issue<Value>
 	}

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -40,7 +40,7 @@ namespace $ {
 			return $mol_fail( new TypeError( issue.message, { cause: {
 				value,
 				schema: this,
-				issue: issue_eager( issue )
+				issue: $mol_schema_issue_eager( issue )
 			} } ) )
 		}
 		
@@ -60,7 +60,7 @@ namespace $ {
 		): $mol_schema_issues<Value> {}
 
 		static issues< This extends typeof $mol_schema_any, Value >( this: This, value: Value ) {
-			return Array.from( this.issues_lazy( value ), issue_eager )
+			return Array.from( this.issues_lazy( value ), $mol_schema_issue_eager )
 		}
 		
 		static get ['~standard']() {
@@ -78,10 +78,10 @@ namespace $ {
 
 	}
 	type Issue<Value> = Omit< $mol_schema_issue<Value>, 'issues' > & { issues?: Issue<Value>[] }
-	const issue_eager = (issue: $mol_schema_issue) => {
+	export function $mol_schema_issue_eager< Value >( issue: $mol_schema_issue<Value> ) {
 		const { issues, ...i } = issue
 		if( issues ) Object.defineProperty( i, "issues", {
-			get: $mol_memo.func( () => Array.from(issues, issue_eager) )
+			get: $mol_memo.func( () => Array.from( issues, $mol_schema_issue_eager ) )
 		} )
 		return i as Issue<Value>
 	}

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -5,18 +5,19 @@ namespace $ {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
 		readonly issues?: $mol_schema_issues
-		readonly kind?: string | undefined
+		readonly kind?: string[] | undefined // For backward compatibility as "Wrong field" / "Wrong type"
+		readonly error?: unknown // For backward compatibility with "Cannot convert undefined or null to object"
 	}
 	export type $mol_schema_issues = IterableIterator<$mol_schema_issue, void, unknown>
 
-	class AggregationErrorLazy extends AggregateError {
-		constructor(errors_: () => Iterable<Error>, message: string, options: ErrorOptions) {
-			super([], message, options)
-			Object.defineProperty(this, 'errors', {
-				get: () => [ ...errors_() ],
-				enumerable: false,
-				configurable: true,
-			})
+	class AggregateErrorLazy extends AggregateError {
+		constructor(
+			errors: () => Iterable<unknown, void, unknown>,
+			message: string,
+			options?: ErrorOptions
+		) {
+			super( [], message, options )
+			Object.defineProperty( this, "errors", { get: $mol_memo.func(()=>[ ...errors() ]) } )
 		}
 	}
 
@@ -43,35 +44,61 @@ namespace $ {
 			return this.check( value )
 		}
 		
-		static _get_error( { issues, path, kind, message }: $mol_schema_issue, options: ErrorOptions): Error {
-			const last = path.at(-1)
-			if( typeof last === "object" ) message = "Wrong key"
-			else if( typeof last === "number" ) message = "Wrong item"
-			else if( kind ) message = `Wrong ${kind}`
+		static _get_value(value: any, path: $mol_schema_issue_path) {
+			for( const key of path ) {
+				if( typeof key === "object" ) return key.key
+				value = value?.[key]
+			}
+			return value
+		}
+
+		static _get_error( { issues, path: [ p, ... path ], kind, message, error }: $mol_schema_issue, value: unknown): unknown {
+			if( error ) return error
+			const cause = { value, schema: this } as Record<string, unknown>
+			const v = this._get_value(value, [p])
+			const m = message
 			const self = this
-			if( issues ) return new AggregationErrorLazy(
-				function* () { for( const i of issues ) yield self._get_error( i, options ) }, // issues.map
-				message,
-				options
-			)
-			return new TypeError( message, options )
+
+			const add_error = (kind?: string[]) => Object.defineProperty( cause, 'error', {
+				get: $mol_memo.func( () => this._get_error({ message: m, path, issues, kind }, v ) ),
+				enumerable: true,
+			} )
+			if( typeof p === "object" ) {
+				add_error(kind)
+				message = "Wrong key"
+				cause.key = p.key
+			} else if( typeof p === "number" ) {
+				add_error(kind)
+				message = "Wrong item"
+				cause.index = p
+			} else if( kind?.[0] ) {
+				const [ k, ...other ] = kind ?? []
+				if( p ) {
+					add_error(other)
+					cause[ k === "val" ? "key" : k ] = p
+				}
+				message = `Wrong ${k}`
+			}
+
+			if( !issues ) return new TypeError( message, { cause } )
+			const { value: first } = issues.next()
+			if( !first ) return new TypeError( message, { cause } )
+
+			const f = this._get_error( first, this._get_value( value, first.path ) )
+			const { value: i, done } = issues.next()
+			if( done ) return f
+
+			return new AggregateErrorLazy( function*() {
+				yield f
+				yield self._get_error(i, self._get_value(value, i.path))
+				for( const i of issues ) yield self._get_error(i, self._get_value(value, i.path))
+			}, message, { cause: { value, schema: this } } )
 		}
 
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const issues = this.issues_lazy( value )
-			const { value: first, done } = issues.next()
-			if( done ) return value
-			const options = { cause: { value, schema: this } }
-			const f = this._get_error( first, options )
-			const { value: second, done: d } = issues.next()
-			if( d ) return $mol_fail( f )
-			const self = this
-			return $mol_fail( new AggregationErrorLazy( function*() {
-				yield f
-				yield self._get_error( second, options )
-				for( const i of issues ) yield self._get_error( i, options )
-			}, f.message, options ) )
+			const { value: first }  = this.issues_lazy( value ).next()
+			return first ? $mol_fail( this._get_error( first, value ) ) : value
 		}
 		
 		/** Type-caster that normalizes wrong values. */
@@ -93,12 +120,9 @@ namespace $ {
 			type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }
 			const issue = ( i: $mol_schema_issue ): Issue => {
 				const { issues } = i
-				if( issues ) return {
-					...i,
-					get issues() {
-						return Array.from( issues, issue )
-					},
-				}
+				if( issues ) Object.defineProperty( i, "issues", {
+					get: $mol_memo.func( () => Array.from(issues, issue) )
+				} )
 				return i as Issue
 			}
 			return Array.from( this.issues_lazy( value ), issue )

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -1,14 +1,14 @@
 namespace $ {
 	
 	export type $mol_schema_issue_path = ReadonlyArray<PropertyKey | { key: PropertyKey }>
-	export type $mol_schema_issue<Value=unknown> = {
+	export type $mol_schema_issue<Value> = {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
-		readonly issues?: $mol_schema_issues
+		readonly issues?: $mol_schema_issues<Value>
 		readonly value: Value
 		readonly schema: typeof $mol_schema_any
 	}
-	export type $mol_schema_issues = IterableIterator<$mol_schema_issue, void, unknown>
+	export type $mol_schema_issues<Value> = IterableIterator<$mol_schema_issue<Value>, void, unknown>
 
 	export class $mol_schema_any extends Object {
 		
@@ -57,7 +57,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {}
+		): $mol_schema_issues<Value> {}
 
 		static issues< This extends typeof $mol_schema_any, Value >( this: This, value: Value ) {
 			return Array.from( this.issues_lazy( value ), issue_eager )
@@ -77,12 +77,12 @@ namespace $ {
 		}
 
 	}
-	type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }
+	type Issue<Value> = Omit< $mol_schema_issue<Value>, 'issues' > & { issues?: Issue<Value>[] }
 	const issue_eager = (issue: $mol_schema_issue) => {
 		const { issues, ...i } = issue
 		if( issues ) Object.defineProperty( i, "issues", {
 			get: $mol_memo.func( () => Array.from(issues, issue_eager) )
 		} )
-		return i as Issue
+		return i as Issue<Value>
 	}
 }

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -1,4 +1,12 @@
 namespace $ {
+
+	export type $mol_schema_issue_path = ReadonlyArray<PropertyKey | { key: PropertyKey }>
+	export type $mol_schema_issue = {
+		readonly message: string
+		readonly path: $mol_schema_issue_path
+		readonly issues?: Generator<$mol_schema_issue, void, unknown>
+	}
+
 	export class $mol_schema_any extends Object {
 		
 		static [ Symbol.toStringTag ]: string
@@ -14,12 +22,8 @@ namespace $ {
 		
 		/** Type-predicate that checks value by schema. */
 		static check< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): value is Value & This['default'] {
-			try {
-				this.guard( value )
-				return true
-			} catch( error ) {
-				return false
-			}
+			const { value: issue } = this.issues_lazy(value).next()
+			return !issue
 		}
 		
 		/** `instanceof` support */
@@ -29,6 +33,8 @@ namespace $ {
 		
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
+			const { value: issue } = this.issues_lazy(value).next()
+			if (issue) $mol_fail(new TypeError(issue.message, { cause: { value, schema: this, path: issue.path } }))
 			return value
 		}
 		
@@ -44,6 +50,28 @@ namespace $ {
 		
 		/** Default value which conforms schema. */
 		static default = null as unknown
+
+		static *issues_lazy<This extends typeof $mol_schema_any, Value>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		): Generator<$mol_schema_issue, void, unknown> {}
+
+		static issues<This extends typeof $mol_schema_any, Value>(value: Value) {
+			type Issue = Omit<$mol_schema_issue, 'issues'> & { issues?: Issue[] }
+			const issue = (i: $mol_schema_issue): Issue => {
+				const { issues } = i
+				if (issues)
+					return {
+						...i,
+						get issues() {
+							return Array.from(issues, issue)
+						},
+					}
+				return i as Issue
+			}
+			return Array.from(this.issues_lazy(value), issue)
+		}
 		
 	}
 }

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -1,10 +1,12 @@
 namespace $ {
 	
 	export type $mol_schema_issue_path = ReadonlyArray<PropertyKey | { key: PropertyKey }>
-	export type $mol_schema_issue = {
+	export type $mol_schema_issue<Value=unknown> = {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
 		readonly issues?: $mol_schema_issues
+		readonly value: Value
+		readonly schema: typeof $mol_schema_any
 	}
 	export type $mol_schema_issues = IterableIterator<$mol_schema_issue, void, unknown>
 

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -57,7 +57,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): Generator<$mol_schema_issue, void, unknown> {}
 
-		static issues<This extends typeof $mol_schema_any, Value>(value: Value) {
+		static issues<This extends typeof $mol_schema_any, Value>(this: This, value: Value) {
 			type Issue = Omit<$mol_schema_issue, 'issues'> & { issues?: Issue[] }
 			const issue = (i: $mol_schema_issue): Issue => {
 				const { issues } = i
@@ -73,5 +73,18 @@ namespace $ {
 			return Array.from(this.issues_lazy(value), issue)
 		}
 		
+		static get ["~standard"]() {
+			return {
+				version: 1,
+				vendor: "$mol_schema",
+				validate: (value: unknown) => {
+					const issues = this.issues_lazy(value)
+					const first = issues.next()
+					if( first.done ) return { value }
+					return { get issues() { return [ first, ...issues ] } }
+				}
+			}
+		}
+
 	}
 }

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -1,5 +1,5 @@
 namespace $ {
-
+	
 	export type $mol_schema_issue_path = ReadonlyArray<PropertyKey | { key: PropertyKey }>
 	export type $mol_schema_issue = {
 		readonly message: string
@@ -22,8 +22,7 @@ namespace $ {
 		
 		/** Type-predicate that checks value by schema. */
 		static check< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): value is Value & This['default'] {
-			const { value: issue } = this.issues_lazy(value).next()
-			return !issue
+			return this.issues_lazy( value ).next().done || false
 		}
 		
 		/** `instanceof` support */
@@ -33,52 +32,47 @@ namespace $ {
 		
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const { value: issue } = this.issues_lazy(value).next()
+			const { value: issue } = this.issues_lazy( value ).next()
 			if( issue ) $mol_fail( new TypeError( issue.message, { cause: { ...issue, value, schema: this } } ) )
 			return value
 		}
 		
 		/** Type-caster that normalizes wrong values. */
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
-			try {
-				this.guard( value )
-				return value
-			} catch ( error ) {
-				return this.default
-			}
+			if( this.issues_lazy( value ).next().done ) return value
+			return this.default
 		}
 		
 		/** Default value which conforms schema. */
 		static default = null as unknown
 
-		static *issues_lazy<This extends typeof $mol_schema_any, Value>(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
 		): Generator<$mol_schema_issue, void, unknown> {}
 
-		static issues<This extends typeof $mol_schema_any, Value>(this: This, value: Value) {
-			type Issue = Omit<$mol_schema_issue, 'issues'> & { issues?: Issue[] }
-			const issue = (i: $mol_schema_issue): Issue => {
+		static issues< This extends typeof $mol_schema_any, Value >( this: This, value: Value ) {
+			type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }
+			const issue = ( i: $mol_schema_issue ): Issue => {
 				const { issues } = i
-				if (issues)
-					return {
-						...i,
-						get issues() {
-							return Array.from(issues, issue)
-						},
-					}
+				if( issues ) return {
+					...i,
+					get issues() {
+						return Array.from( issues, issue )
+					},
+				}
 				return i as Issue
 			}
-			return Array.from(this.issues_lazy(value), issue)
+			return Array.from( this.issues_lazy( value ), issue )
 		}
 		
-		static get ["~standard"]() {
+		static get ['~standard']() {
 			return {
 				version: 1,
-				vendor: "$mol_schema",
-				validate: (value: unknown) => {
-					const issues = this.issues_lazy(value)
+				vendor: '$mol_schema',
+				validate: ( value: unknown )=> {
+					const issues = this.issues_lazy( value )
 					const first = issues.next()
 					if( first.done ) return { value }
 					return { get issues() { return [ first, ...issues ] } }

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -4,7 +4,18 @@ namespace $ {
 	export type $mol_schema_issue = {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
-		readonly issues?: Generator<$mol_schema_issue, void, unknown>
+		readonly issues?: IterableIterator<$mol_schema_issue, void, unknown>
+	}
+
+	class AggregationErrorLazy extends AggregateError {
+		constructor(errors_: () => Iterable<Error>, message: string, options: ErrorOptions) {
+			super([], message, options)
+			Object.defineProperty(this, 'errors', {
+				get: () => [ ...errors_() ],
+				enumerable: false,
+				configurable: true,
+			})
+		}
 	}
 
 	export class $mol_schema_any extends Object {
@@ -30,11 +41,35 @@ namespace $ {
 			return this.check( value )
 		}
 		
+		static _get_error( { issues, path, kind, message }: $mol_schema_issue & { kind?: string }, options: ErrorOptions): Error {
+			const last = path.at(-1)
+			if( typeof last === "object" ) message = "Wrong key"
+			else if( typeof last === "number" ) message = "Wrong item"
+			else if( kind ) message = `Wrong ${kind}`
+			const self = this
+			if( issues ) return new AggregationErrorLazy(
+				function* () { for( const i of issues ) yield self._get_error( i, options ) }, // issues.map
+				message,
+				options
+			)
+			return new TypeError( message, options )
+		}
+
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const { value: issue } = this.issues_lazy( value ).next()
-			if( issue ) $mol_fail( new TypeError( issue.message, { cause: { ...issue, value, schema: this } } ) )
-			return value
+			const issues = this.issues_lazy( value )
+			const { value: first, done } = issues.next()
+			if( done ) return value
+			const options = { cause: { value, schema: this } }
+			const f = this._get_error( first, options )
+			const { value: second, done: d } = issues.next()
+			if( d ) return $mol_fail( f )
+			const self = this
+			return $mol_fail( new AggregationErrorLazy( function*() {
+				yield f
+				yield self._get_error( second, options )
+				for( const i of issues ) yield self._get_error( i, options )
+			}, f.message, options ) )
 		}
 		
 		/** Type-caster that normalizes wrong values. */
@@ -50,7 +85,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): Generator<$mol_schema_issue, void, unknown> {}
+		): IterableIterator<$mol_schema_issue, void, unknown> {}
 
 		static issues< This extends typeof $mol_schema_any, Value >( this: This, value: Value ) {
 			type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -4,8 +4,10 @@ namespace $ {
 	export type $mol_schema_issue = {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
-		readonly issues?: IterableIterator<$mol_schema_issue, void, unknown>
+		readonly issues?: $mol_schema_issues
+		readonly kind?: string | undefined
 	}
+	export type $mol_schema_issues = IterableIterator<$mol_schema_issue, void, unknown>
 
 	class AggregationErrorLazy extends AggregateError {
 		constructor(errors_: () => Iterable<Error>, message: string, options: ErrorOptions) {
@@ -41,7 +43,7 @@ namespace $ {
 			return this.check( value )
 		}
 		
-		static _get_error( { issues, path, kind, message }: $mol_schema_issue & { kind?: string | undefined }, options: ErrorOptions): Error {
+		static _get_error( { issues, path, kind, message }: $mol_schema_issue, options: ErrorOptions): Error {
 			const last = path.at(-1)
 			if( typeof last === "object" ) message = "Wrong key"
 			else if( typeof last === "number" ) message = "Wrong item"

--- a/schema/any/any.ts
+++ b/schema/any/any.ts
@@ -5,21 +5,8 @@ namespace $ {
 		readonly message: string
 		readonly path: $mol_schema_issue_path
 		readonly issues?: $mol_schema_issues
-		readonly kind?: string[] | undefined // For backward compatibility as "Wrong field" / "Wrong type"
-		readonly error?: unknown // For backward compatibility with "Cannot convert undefined or null to object"
 	}
 	export type $mol_schema_issues = IterableIterator<$mol_schema_issue, void, unknown>
-
-	class AggregateErrorLazy extends AggregateError {
-		constructor(
-			errors: () => Iterable<unknown, void, unknown>,
-			message: string,
-			options?: ErrorOptions
-		) {
-			super( [], message, options )
-			Object.defineProperty( this, "errors", { get: $mol_memo.func(()=>[ ...errors() ]) } )
-		}
-	}
 
 	export class $mol_schema_any extends Object {
 		
@@ -44,61 +31,15 @@ namespace $ {
 			return this.check( value )
 		}
 		
-		static _get_value(value: any, path: $mol_schema_issue_path) {
-			for( const key of path ) {
-				if( typeof key === "object" ) return key.key
-				value = value?.[key]
-			}
-			return value
-		}
-
-		static _get_error( { issues, path: [ p, ... path ], kind, message, error }: $mol_schema_issue, value: unknown): unknown {
-			if( error ) return error
-			const cause = { value, schema: this } as Record<string, unknown>
-			const v = this._get_value(value, [p])
-			const m = message
-			const self = this
-
-			const add_error = (kind?: string[]) => Object.defineProperty( cause, 'error', {
-				get: $mol_memo.func( () => this._get_error({ message: m, path, issues, kind }, v ) ),
-				enumerable: true,
-			} )
-			if( typeof p === "object" ) {
-				add_error(kind)
-				message = "Wrong key"
-				cause.key = p.key
-			} else if( typeof p === "number" ) {
-				add_error(kind)
-				message = "Wrong item"
-				cause.index = p
-			} else if( kind?.[0] ) {
-				const [ k, ...other ] = kind ?? []
-				if( p ) {
-					add_error(other)
-					cause[ k === "val" ? "key" : k ] = p
-				}
-				message = `Wrong ${k}`
-			}
-
-			if( !issues ) return new TypeError( message, { cause } )
-			const { value: first } = issues.next()
-			if( !first ) return new TypeError( message, { cause } )
-
-			const f = this._get_error( first, this._get_value( value, first.path ) )
-			const { value: i, done } = issues.next()
-			if( done ) return f
-
-			return new AggregateErrorLazy( function*() {
-				yield f
-				yield self._get_error(i, self._get_value(value, i.path))
-				for( const i of issues ) yield self._get_error(i, self._get_value(value, i.path))
-			}, message, { cause: { value, schema: this } } )
-		}
-
 		/** Type-parser that fails of wrong values. */
 		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const { value: first }  = this.issues_lazy( value ).next()
-			return first ? $mol_fail( this._get_error( first, value ) ) : value
+			const { value: issue }  = this.issues_lazy( value ).next()
+			if (!issue) return value
+			return $mol_fail( new TypeError( issue.message, { cause: {
+				value,
+				schema: this,
+				issue: issue_eager( issue )
+			} } ) )
 		}
 		
 		/** Type-caster that normalizes wrong values. */
@@ -114,18 +55,10 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): IterableIterator<$mol_schema_issue, void, unknown> {}
+		): $mol_schema_issues {}
 
 		static issues< This extends typeof $mol_schema_any, Value >( this: This, value: Value ) {
-			type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }
-			const issue = ( i: $mol_schema_issue ): Issue => {
-				const { issues } = i
-				if( issues ) Object.defineProperty( i, "issues", {
-					get: $mol_memo.func( () => Array.from(issues, issue) )
-				} )
-				return i as Issue
-			}
-			return Array.from( this.issues_lazy( value ), issue )
+			return Array.from( this.issues_lazy( value ), issue_eager )
 		}
 		
 		static get ['~standard']() {
@@ -141,5 +74,13 @@ namespace $ {
 			}
 		}
 
+	}
+	type Issue = Omit< $mol_schema_issue, 'issues' > & { issues?: Issue[] }
+	const issue_eager = (issue: $mol_schema_issue) => {
+		const { issues, ...i } = issue
+		if( issues ) Object.defineProperty( i, "issues", {
+			get: $mol_memo.func( () => Array.from(issues, issue_eager) )
+		} )
+		return i as Issue
 	}
 }

--- a/schema/bigint/bigint.test.ts
+++ b/schema/bigint/bigint.test.ts
@@ -12,7 +12,7 @@ namespace $.$$ {
 			$mol_assert_equal( 1n, $mol_schema_bigint.cast( 1 ) )
 			
 			$mol_assert_equal( 0n, $mol_schema_bigint.guard( 0n ) )
-			$mol_assert_fail( ()=> $mol_schema_bigint.guard( 1 ), 'Wrong bigint' )
+			$mol_assert_fail( ()=> $mol_schema_bigint.guard( 1 ), 'Wrong type' )
 			
 		},
 		

--- a/schema/bigint/bigint.test.ts
+++ b/schema/bigint/bigint.test.ts
@@ -12,7 +12,7 @@ namespace $.$$ {
 			$mol_assert_equal( 1n, $mol_schema_bigint.cast( 1 ) )
 			
 			$mol_assert_equal( 0n, $mol_schema_bigint.guard( 0n ) )
-			$mol_assert_fail( ()=> $mol_schema_bigint.guard( 1 ), 'Wrong type' )
+			$mol_assert_fail( ()=> $mol_schema_bigint.guard( 1 ), 'Wrong bigint' )
 			
 		},
 		

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'bigint' ) return
-			yield { message: 'Wrong bigint', path, kind: [ 'type' ] }
+			yield { message: 'Wrong bigint', path }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'bigint' ) return
-			yield { message: 'Wrong bigint', path, kind: "type" }
+			yield { message: 'Wrong bigint', path, kind: [ 'type' ] }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -1,11 +1,11 @@
 namespace $ {
 	export class $mol_schema_bigint extends $mol_schema_any {
 		
-		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		) {
+		): $mol_schema_issues {
 			if( typeof value === 'bigint' ) return
 			yield { message: 'Wrong bigint', path, kind: "type" }
 		}

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -1,10 +1,7 @@
 namespace $ {
 	export class $mol_schema_bigint extends $mol_schema_any {
 		
-		static override *issues_lazy<
-			This extends typeof $mol_schema_any,
-			Value
-		>(
+		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		) {
 			if( typeof value === 'bigint' ) return
-			yield { message: 'Wrong bigint', path }
+			yield { message: 'Wrong bigint', path, kind: "type" }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -1,9 +1,16 @@
 namespace $ {
 	export class $mol_schema_bigint extends $mol_schema_any {
 		
-		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			if( typeof value === 'bigint' ) return value
-			return $mol_fail( new TypeError( 'Wrong type', { cause: { value, schema: this } } ) )
+		static override *issues_lazy<
+			This extends typeof $mol_schema_any,
+			Value
+		>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		) {
+			if( typeof value === 'bigint' ) return
+			yield { message: 'Wrong bigint', path }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'bigint' ) return
-			yield { message: 'Wrong bigint', path }
+			yield { message: 'Wrong bigint', path, value, schema: this }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/bigint/bigint.ts
+++ b/schema/bigint/bigint.ts
@@ -5,7 +5,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {
+		): $mol_schema_issues<Value> {
 			if( typeof value === 'bigint' ) return
 			yield { message: 'Wrong bigint', path, value, schema: this }
 		}

--- a/schema/boolean/boolean.test.ts
+++ b/schema/boolean/boolean.test.ts
@@ -14,7 +14,7 @@ namespace $.$$ {
 			$mol_assert_equal( false, $mol_schema_boolean.cast( 'true' ) )
 			
 			$mol_assert_equal( false, $mol_schema_boolean.guard( false ) )
-			$mol_assert_fail( ()=> $mol_schema_boolean.guard( null ), 'Wrong type' )
+			$mol_assert_fail( ()=> $mol_schema_boolean.guard( null ), 'Wrong boolean' )
 			
 		},
 		

--- a/schema/boolean/boolean.test.ts
+++ b/schema/boolean/boolean.test.ts
@@ -14,7 +14,7 @@ namespace $.$$ {
 			$mol_assert_equal( false, $mol_schema_boolean.cast( 'true' ) )
 			
 			$mol_assert_equal( false, $mol_schema_boolean.guard( false ) )
-			$mol_assert_fail( ()=> $mol_schema_boolean.guard( null ), 'Wrong boolean' )
+			$mol_assert_fail( ()=> $mol_schema_boolean.guard( null ), 'Wrong type' )
 			
 		},
 		

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -1,9 +1,16 @@
 namespace $ {
 	export class $mol_schema_boolean extends $mol_schema_any {
 		
-		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			if( typeof value === 'boolean' ) return value
-			return $mol_fail( new TypeError( 'Wrong type', { cause: { value, schema: this } } ) )
+		static override *issues_lazy<
+			This extends typeof $mol_schema_any,
+			Value
+		>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		) {
+			if( typeof value === 'boolean' ) return
+			yield { message: 'Wrong boolean', path }
 		}
 		
 		static default = false

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'boolean' ) return
-			yield { message: 'Wrong boolean', path }
+			yield { message: 'Wrong boolean', path, value, schema: this }
 		}
 		
 		static default = false

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -5,7 +5,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {
+		): $mol_schema_issues<Value> {
 			if( typeof value === 'boolean' ) return
 			yield { message: 'Wrong boolean', path, value, schema: this }
 		}

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'boolean' ) return
-			yield { message: 'Wrong boolean', path, kind: [ 'type' ] }
+			yield { message: 'Wrong boolean', path }
 		}
 		
 		static default = false

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -1,10 +1,7 @@
 namespace $ {
 	export class $mol_schema_boolean extends $mol_schema_any {
 		
-		static override *issues_lazy<
-			This extends typeof $mol_schema_any,
-			Value
-		>(
+		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -1,11 +1,11 @@
 namespace $ {
 	export class $mol_schema_boolean extends $mol_schema_any {
 		
-		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		) {
+		): $mol_schema_issues {
 			if( typeof value === 'boolean' ) return
 			yield { message: 'Wrong boolean', path, kind: "type" }
 		}

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'boolean' ) return
-			yield { message: 'Wrong boolean', path, kind: "type" }
+			yield { message: 'Wrong boolean', path, kind: [ 'type' ] }
 		}
 		
 		static default = false

--- a/schema/boolean/boolean.ts
+++ b/schema/boolean/boolean.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		) {
 			if( typeof value === 'boolean' ) return
-			yield { message: 'Wrong boolean', path }
+			yield { message: 'Wrong boolean', path, kind: "type" }
 		}
 		
 		static default = false

--- a/schema/dict/dict.test.ts
+++ b/schema/dict/dict.test.ts
@@ -23,8 +23,8 @@ namespace $ {
 			
 			$mol_assert_equal( {}, Flags.guard( {} ) )
 			$mol_assert_equal( { foo: false }, Flags.guard({ foo: false }) )
-			$mol_assert_fail( ()=> Flags.guard({ foo: 123 }), 'Wrong boolean' )
-			$mol_assert_fail( ()=> Flags.guard({ f00: 123 }), 'Wrong pattern' )
+			$mol_assert_fail( ()=> Flags.guard({ foo: 123 }), 'Wrong val' )
+			$mol_assert_fail( ()=> Flags.guard({ f00: 123 }), 'Wrong key' )
 			
 		},
 		

--- a/schema/dict/dict.test.ts
+++ b/schema/dict/dict.test.ts
@@ -23,8 +23,8 @@ namespace $ {
 			
 			$mol_assert_equal( {}, Flags.guard( {} ) )
 			$mol_assert_equal( { foo: false }, Flags.guard({ foo: false }) )
-			$mol_assert_fail( ()=> Flags.guard({ foo: 123 }), 'Wrong val' )
-			$mol_assert_fail( ()=> Flags.guard({ f00: 123 }), 'Wrong key' )
+			$mol_assert_fail( ()=> Flags.guard({ foo: 123 }), 'Wrong boolean' )
+			$mol_assert_fail( ()=> Flags.guard({ f00: 123 }), 'Wrong pattern' )
 			
 		},
 		

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -18,18 +18,11 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
-				try {
-					var proto = Object.getPrototypeOf( Object.getPrototypeOf( value ) )
-				} catch( error ) {
-					yield { message: 'Non dictionary', path, error }
-					return
-				}
-				if ( proto )
+				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non dictionary', path }
 				else for( const key in value ) {
 					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
-					for( const i of Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] ) )
-						yield { ...i, kind: [ "val", ...i.kind ?? [] ] }
+					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
 				}
 			}
 			

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -13,29 +13,20 @@ namespace $ {
 				return '$mol_schema_dict<' + $mol_key( Pair ) + '>'
 			}
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				
-				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) ) {
-					return $mol_fail( new TypeError( 'Non dictionary', { cause: { value, schema: this } } ) )
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
+					yield { message: 'Non dictionary', path }
+				else for( const key in value ) {
+					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
+					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
 				}
-				
-				for( const key in value ) {
-					
-					try {
-						Pair[0].guard( key )
-					} catch( error ) {
-						return $mol_fail( new TypeError( 'Wrong key', { cause: { key, error, value, schema: this } } ) )
-					}
-					
-					try {
-						Pair[1].guard( ( value as any )[ key ] )
-					} catch( error ) {
-						return $mol_fail( new TypeError( 'Wrong val', { cause: { key, error, value, schema: this } } ) )
-					}
-					
-				}
-				
-				return value
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -22,7 +22,8 @@ namespace $ {
 					yield { message: 'Non dictionary', path }
 				else for( const key in value ) {
 					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
-					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
+					for( const i of Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] ) )
+						yield { ...i, kind: "val" }
 				}
 			}
 			

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -18,15 +18,26 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
-				if( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
+				try {
+					var proto = Object.getPrototypeOf( Object.getPrototypeOf( value ) )
+				} catch( error ) {
+					yield { message: 'Non dictionary', path, error }
+					return
+				}
+				if ( proto )
 					yield { message: 'Non dictionary', path }
 				else for( const key in value ) {
 					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
 					for( const i of Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] ) )
-						yield { ...i, kind: "val" }
+						yield { ...i, kind: [ "val", ...i.kind ?? [] ] }
 				}
 			}
 			
+			static guard<This extends typeof $mol_schema_any, Value>(this: This, value: Value) {
+				if (!value) Object.getPrototypeOf( value )
+				return super.guard(value)
+			}
+
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
 				
 				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) ) return this.default

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -19,16 +19,11 @@ namespace $ {
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
-					yield { message: 'Non dictionary', path }
+					yield { message: 'Non dictionary', path, value, schema: this }
 				else for( const key in value ) {
 					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
 					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
 				}
-			}
-			
-			static guard<This extends typeof $mol_schema_any, Value>(this: This, value: Value) {
-				if (!value) Object.getPrototypeOf( value )
-				return super.guard(value)
 			}
 
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -21,7 +21,7 @@ namespace $ {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non dictionary', path, value, schema: this }
 				else for( const key in value ) {
-					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] )
+					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] ) as any
 					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
 				}
 			}

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -13,10 +13,7 @@ namespace $ {
 				return '$mol_schema_dict<' + $mol_key( Pair ) + '>'
 			}
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
@@ -42,7 +39,7 @@ namespace $ {
 				return res
 			}
 			
-			static default = {} as Record< Pair[0]['default'], Pair[1]['default'] > 
+			static default = {} as Record< Pair[0]['default'], Pair[1]['default'] >
 			
 		}
 		

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -17,7 +17,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non dictionary', path, value, schema: this }
 				else for( const key in value ) {

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -13,11 +13,11 @@ namespace $ {
 				return '$mol_schema_dict<' + $mol_key( Pair ) + '>'
 			}
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				if( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non dictionary', path }
 				else for( const key in value ) {

--- a/schema/dict/dict.ts
+++ b/schema/dict/dict.ts
@@ -18,14 +18,14 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues<Value> {
-				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
+				if( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non dictionary', path, value, schema: this }
 				else for( const key in value ) {
 					yield* Pair[0].issues_lazy( key, [ ...path, { key } ] ) as any
 					yield* Pair[1].issues_lazy( ( value as any )[ key ], [ ...path, key ] )
 				}
 			}
-
+			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
 				
 				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) ) return this.default
@@ -39,7 +39,7 @@ namespace $ {
 				return res
 			}
 			
-			static default = {} as Record< Pair[0]['default'], Pair[1]['default'] >
+			static default = {} as Record< Pair[0]['default'], Pair[1]['default'] > 
 			
 		}
 		

--- a/schema/enum/enum.ts
+++ b/schema/enum/enum.ts
@@ -12,7 +12,7 @@ namespace $ {
 				return '$mol_schema_enum<' + $mol_key(Options) + '>'
 			}	
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/enum/enum.ts
+++ b/schema/enum/enum.ts
@@ -16,9 +16,9 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				if( Options.some( Option => Object.is( Option, value ) ) ) return
-				yield { message: 'Wrong option', path }
+				yield { message: 'Wrong option', path, value, schema: this }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/enum/enum.ts
+++ b/schema/enum/enum.ts
@@ -16,7 +16,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				if( Options.some( Option => Object.is( Option, value ) ) ) return
 				yield { message: 'Wrong option', path, value, schema: this }
 			}

--- a/schema/enum/enum.ts
+++ b/schema/enum/enum.ts
@@ -12,10 +12,7 @@ namespace $ {
 				return '$mol_schema_enum<' + $mol_key(Options) + '>'
 			}	
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/enum/enum.ts
+++ b/schema/enum/enum.ts
@@ -12,9 +12,16 @@ namespace $ {
 				return '$mol_schema_enum<' + $mol_key(Options) + '>'
 			}	
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				if( Options.some( Option => Object.is( Option, value ) ) ) return value
-				return $mol_fail( new TypeError( 'Wrong option', { cause: { value, schema: this } } ) )
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( Options.some( Option => Object.is( Option, value ) ) ) return
+				yield { message: 'Wrong option', path }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/every/every.test.ts
+++ b/schema/every/every.test.ts
@@ -29,7 +29,7 @@ namespace $.$$ {
 			$mol_assert_equal( 5, Narrow.guard( 5 ) )
 			$mol_assert_fail( ()=> Narrow.guard( 2 ), 'Too small' )
 			$mol_assert_fail( ()=> Narrow.guard( 10 ), 'Too large' )
-			$mol_assert_fail( ()=> Narrow.guard( '' ), 'Wrong number' )
+			$mol_assert_fail( ()=> Narrow.guard( '' ), 'Wrong type' )
 			
 		},
 		

--- a/schema/every/every.test.ts
+++ b/schema/every/every.test.ts
@@ -29,7 +29,7 @@ namespace $.$$ {
 			$mol_assert_equal( 5, Narrow.guard( 5 ) )
 			$mol_assert_fail( ()=> Narrow.guard( 2 ), 'Too small' )
 			$mol_assert_fail( ()=> Narrow.guard( 10 ), 'Too large' )
-			$mol_assert_fail( ()=> Narrow.guard( '' ), 'Wrong type' )
+			$mol_assert_fail( ()=> Narrow.guard( '' ), 'Wrong number' )
 			
 		},
 		

--- a/schema/every/every.ts
+++ b/schema/every/every.ts
@@ -12,10 +12,7 @@ namespace $ {
 				return '$mol_schema_every<' + $mol_key(Schemas) + '>'
 			}	
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
@@ -25,11 +22,11 @@ namespace $ {
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
-				for( const Scheme of Schemas ) value = Scheme.cast( value )
+				for( const Schema of Schemas ) value = Schema.cast( value )
 				return value
 			}
 			
-			static default = Schemas.find( Scheme => this.check( Scheme.default ) ) as $mol_type_intersect< Schemas[number]['default'] >
+			static default = Schemas.find( Schema => this.check( Schema.default ) ) as $mol_type_intersect< Schemas[number]['default'] >
 			
 		}
 		

--- a/schema/every/every.ts
+++ b/schema/every/every.ts
@@ -12,13 +12,16 @@ namespace $ {
 				return '$mol_schema_every<' + $mol_key(Schemas) + '>'
 			}	
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				
-				for( const Schema of Schemas ) {
-					Schema.guard( value )
-				}
-				
-				return value
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				for( const Schema of Schemas )
+					yield* Schema.issues_lazy( value, path )
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/every/every.ts
+++ b/schema/every/every.ts
@@ -12,7 +12,7 @@ namespace $ {
 				return '$mol_schema_every<' + $mol_key(Schemas) + '>'
 			}	
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/float/float.test.ts
+++ b/schema/float/float.test.ts
@@ -14,7 +14,7 @@ namespace $.$$ {
 			$mol_assert_equal( Number.NaN, $mol_schema_float.cast( '0' ) )
 			
 			$mol_assert_equal( Number.EPSILON, $mol_schema_float.guard( Number.EPSILON ) )
-			$mol_assert_fail( ()=> $mol_schema_float.guard( '0' ), 'Wrong type' )
+			$mol_assert_fail( ()=> $mol_schema_float.guard( '0' ), 'Wrong float' )
 			
 		},
 		

--- a/schema/float/float.test.ts
+++ b/schema/float/float.test.ts
@@ -14,7 +14,7 @@ namespace $.$$ {
 			$mol_assert_equal( Number.NaN, $mol_schema_float.cast( '0' ) )
 			
 			$mol_assert_equal( Number.EPSILON, $mol_schema_float.guard( Number.EPSILON ) )
-			$mol_assert_fail( ()=> $mol_schema_float.guard( '0' ), 'Wrong float' )
+			$mol_assert_fail( ()=> $mol_schema_float.guard( '0' ), 'Wrong type' )
 			
 		},
 		

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -4,7 +4,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {
+		): $mol_schema_issues<Value> {
 			if( typeof value === 'number' ) return
 			yield { message: 'Wrong float', path, value, schema: this }
 		}

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -6,7 +6,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'number' ) return
-			yield { message: 'Wrong float', path, kind: [ 'type' ] }
+			yield { message: 'Wrong float', path }
 		}
 		
 		static default = Number.NaN

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -1,9 +1,12 @@
 namespace $ {
 	export class $mol_schema_float extends $mol_schema_any {
-		
-		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			if( typeof value === 'number' ) return value
-			return $mol_fail( new TypeError( 'Wrong type', { cause: { value, schema: this } } ) )
+		static override *issues_lazy<This extends typeof $mol_schema_any, Value>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		) {
+			if (typeof value === 'number') return
+			yield { message: 'Wrong float', path }
 		}
 		
 		static default = Number.NaN

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -6,7 +6,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'number' ) return
-			yield { message: 'Wrong float', path, kind: "type" }
+			yield { message: 'Wrong float', path, kind: [ 'type' ] }
 		}
 		
 		static default = Number.NaN

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -1,5 +1,6 @@
 namespace $ {
 	export class $mol_schema_float extends $mol_schema_any {
+		
 		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -6,7 +6,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		) {
 			if( typeof value === 'number' ) return
-			yield { message: 'Wrong float', path }
+			yield { message: 'Wrong float', path, kind: "type" }
 		}
 		
 		static default = Number.NaN

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -1,11 +1,11 @@
 namespace $ {
 	export class $mol_schema_float extends $mol_schema_any {
-		static override *issues_lazy<This extends typeof $mol_schema_any, Value>(
+		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
 		) {
-			if (typeof value === 'number') return
+			if( typeof value === 'number' ) return
 			yield { message: 'Wrong float', path }
 		}
 		

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -6,7 +6,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'number' ) return
-			yield { message: 'Wrong float', path }
+			yield { message: 'Wrong float', path, value, schema: this }
 		}
 		
 		static default = Number.NaN

--- a/schema/float/float.ts
+++ b/schema/float/float.ts
@@ -1,10 +1,10 @@
 namespace $ {
 	export class $mol_schema_float extends $mol_schema_any {
-		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		) {
+		): $mol_schema_issues {
 			if( typeof value === 'number' ) return
 			yield { message: 'Wrong float', path, kind: "type" }
 		}

--- a/schema/instance/instance.ts
+++ b/schema/instance/instance.ts
@@ -14,9 +14,16 @@ namespace $ {
 				return '$mol_schema_instance<' + $$.$mol_func_name(Class) + '>'
 			}
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				if( value != null && Object( value ) instanceof Class ) return value
-				return $mol_fail( new TypeError( 'Wrong class', { cause: { value, schema: this } } ) )
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( value != null && Object( value ) instanceof Class ) return
+				yield { message: 'Wrong class', path }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/instance/instance.ts
+++ b/schema/instance/instance.ts
@@ -14,7 +14,7 @@ namespace $ {
 				return '$mol_schema_instance<' + $$.$mol_func_name(Class) + '>'
 			}
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/instance/instance.ts
+++ b/schema/instance/instance.ts
@@ -14,10 +14,7 @@ namespace $ {
 				return '$mol_schema_instance<' + $$.$mol_func_name(Class) + '>'
 			}
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/instance/instance.ts
+++ b/schema/instance/instance.ts
@@ -20,7 +20,7 @@ namespace $ {
 				path: $mol_schema_issue_path = [],
 			) {
 				if( value != null && Object( value ) instanceof Class ) return
-				yield { message: 'Wrong class', path }
+				yield { message: 'Wrong class', path, value, schema: this }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/integer/integer.test.ts
+++ b/schema/integer/integer.test.ts
@@ -18,7 +18,7 @@ namespace $.$$ {
 			$mol_assert_equal( 0, $mol_schema_integer.cast( 1.5 ) )
 			
 			$mol_assert_equal( 0, $mol_schema_integer.guard( 0 ) )
-			$mol_assert_fail( ()=> $mol_schema_integer.guard( '' ), 'Wrong type' )
+			$mol_assert_fail( ()=> $mol_schema_integer.guard( '' ), 'Wrong number' )
 			$mol_assert_fail( ()=> $mol_schema_integer.guard( Number.NaN ), 'Non finite' )
 			$mol_assert_fail( ()=> $mol_schema_integer.guard( 1.5 ), 'Non integer' )
 			

--- a/schema/integer/integer.test.ts
+++ b/schema/integer/integer.test.ts
@@ -18,7 +18,7 @@ namespace $.$$ {
 			$mol_assert_equal( 0, $mol_schema_integer.cast( 1.5 ) )
 			
 			$mol_assert_equal( 0, $mol_schema_integer.guard( 0 ) )
-			$mol_assert_fail( ()=> $mol_schema_integer.guard( '' ), 'Wrong number' )
+			$mol_assert_fail( ()=> $mol_schema_integer.guard( '' ), 'Wrong type' )
 			$mol_assert_fail( ()=> $mol_schema_integer.guard( Number.NaN ), 'Non finite' )
 			$mol_assert_fail( ()=> $mol_schema_integer.guard( 1.5 ), 'Non integer' )
 			

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -8,8 +8,13 @@ namespace $ {
 			value: Value,
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
-			if( !super.issues_lazy( value, path ).next().done )
-				yield { message: 'Wrong number', path, kind: [ 'type' ] }
+			const { value: issue, done } = super.issues_lazy( value, path ).next()
+			if( !done )
+				yield {
+					message: 'Wrong number',
+					path,
+					issues: (function* () { yield issue })()
+				}
 			else if( !Number.isFinite( value as any ) )
 				yield { message: 'Non finite', path }
 			else if( Math.trunc( value as any ) !== value )

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -3,11 +3,11 @@ namespace $ {
 		
 		$mol_schema_integer = true
 		
-		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		) {
+		): $mol_schema_issues {
 			if( !super.issues_lazy( value, path ).next().done )
 				yield { message: 'Wrong number', path, kind: "type" }
 			else if( !Number.isFinite( value as any ) )

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -7,7 +7,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {
+		): $mol_schema_issues<Value> {
 			const { value: issue, done } = super.issues_lazy( value, path ).next()
 			if( !done )
 				yield {

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -12,13 +12,13 @@ namespace $ {
 			if( !done )
 				yield {
 					message: 'Wrong number',
-					path,
+					path, value, schema: this,
 					issues: (function* () { yield issue })()
 				}
 			else if( !Number.isFinite( value as any ) )
-				yield { message: 'Non finite', path }
+				yield { message: 'Non finite', path, value, schema: this }
 			else if( Math.trunc( value as any ) !== value )
-				yield { message: 'Non integer', path }
+				yield { message: 'Non integer', path, value, schema: this }
 		}
 		
 		static default = 0 as number & $mol_schema_integer

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -9,7 +9,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		) {
 			if( !super.issues_lazy( value, path ).next().done )
-				yield { message: 'Wrong number', path }
+				yield { message: 'Wrong number', path, kind: "type" }
 			else if( !Number.isFinite( value as any ) )
 				yield { message: 'Non finite', path }
 			else if( Math.trunc( value as any ) !== value )

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -3,15 +3,12 @@ namespace $ {
 		
 		$mol_schema_integer = true
 		
-		static override *issues_lazy<
-			This extends typeof $mol_schema_any,
-			Value
-		>(
+		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
 		) {
-			if (!super.issues_lazy(value, path).next().done)
+			if( !super.issues_lazy( value, path ).next().done )
 				yield { message: 'Wrong number', path }
 			else if( !Number.isFinite( value as any ) )
 				yield { message: 'Non finite', path }

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -3,11 +3,20 @@ namespace $ {
 		
 		$mol_schema_integer = true
 		
-		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			const val = super.guard( value )
-			if( !Number.isFinite( val ) ) return $mol_fail( new TypeError( 'Non finite', { cause: { value, schema: this } } ) )
-			if( Math.trunc( val ) !== val ) return $mol_fail( new TypeError( 'Non integer', { cause: { value, schema: this } } ) )
-			return val as Value & typeof this.default
+		static override *issues_lazy<
+			This extends typeof $mol_schema_any,
+			Value
+		>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		) {
+			if (!super.issues_lazy(value, path).next().done)
+				yield { message: 'Wrong number', path }
+			else if( !Number.isFinite( value as any ) )
+				yield { message: 'Non finite', path }
+			else if( Math.trunc( value as any ) !== value )
+				yield { message: 'Non integer', path }
 		}
 		
 		static default = 0 as number & $mol_schema_integer

--- a/schema/integer/integer.ts
+++ b/schema/integer/integer.ts
@@ -9,7 +9,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( !super.issues_lazy( value, path ).next().done )
-				yield { message: 'Wrong number', path, kind: "type" }
+				yield { message: 'Wrong number', path, kind: [ 'type' ] }
 			else if( !Number.isFinite( value as any ) )
 				yield { message: 'Non finite', path }
 			else if( Math.trunc( value as any ) !== value )

--- a/schema/lazy/lazy.ts
+++ b/schema/lazy/lazy.ts
@@ -6,7 +6,7 @@ namespace $ {
 			
 			static Schema = $mol_memo.func( Schema )
 			
-			static override *issues_lazy< Val >(
+			static *issues_lazy< Val >(
 				value: Val,
 				path: $mol_schema_issue_path = [],
 			) {

--- a/schema/lazy/lazy.ts
+++ b/schema/lazy/lazy.ts
@@ -6,8 +6,11 @@ namespace $ {
 			
 			static Schema = $mol_memo.func( Schema )
 			
-			static guard< Val >( value: Val ): Val & Value {
-				return this.Schema().guard( value )
+			static override *issues_lazy< Val >(
+				value: Val,
+				path: $mol_schema_issue_path = [],
+			) {
+				yield* this.Schema().issues_lazy( value, path )
 			}
 			
 			static cast< Val >( value: Val ): Value {

--- a/schema/list/list.test.ts
+++ b/schema/list/list.test.ts
@@ -24,7 +24,7 @@ namespace $.$$ {
 			$mol_assert_equal( [], Vector.guard( [] ) )
 			$mol_assert_equal( [ 123 ], Vector.guard( [ 123 ] ) )
 			$mol_assert_fail( ()=> Vector.guard( 0 ), 'Non array' )
-			$mol_assert_fail( ()=> Vector.guard( [ false ] ), 'Wrong item' )
+			$mol_assert_fail( ()=> Vector.guard( [ false ] ), 'Wrong float' )
 			
 		},
 		

--- a/schema/list/list.test.ts
+++ b/schema/list/list.test.ts
@@ -24,7 +24,7 @@ namespace $.$$ {
 			$mol_assert_equal( [], Vector.guard( [] ) )
 			$mol_assert_equal( [ 123 ], Vector.guard( [ 123 ] ) )
 			$mol_assert_fail( ()=> Vector.guard( 0 ), 'Non array' )
-			$mol_assert_fail( ()=> Vector.guard( [ false ] ), 'Wrong float' )
+			$mol_assert_fail( ()=> Vector.guard( [ false ] ), 'Wrong item' )
 			
 		},
 		

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -22,6 +22,7 @@ namespace $ {
 						yield* Item.issues_lazy( item, [ ...path, index ] )
 				else yield { message: 'Non array', path, value, schema: this }
 			}
+			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
 				if( !Array.isArray( value ) ) return this.default
 				return value.map( item => Item.cast( item ) ) as typeof this.default

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -12,21 +12,19 @@ namespace $ {
 				return '$mol_schema_list<' + $mol_key(Item) + '>'
 			}	
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				
-				if( !Array.isArray( value ) ) return $mol_fail( new TypeError( 'Non array', { cause: { value, schema: this } } ) )
-				
-				for( const [ index, item ] of super.guard( value ).entries() ) {
-					try {
-						Item.guard( item )
-					} catch( error ) {
-						return $mol_fail( new TypeError( 'Wrong item', { cause: { index, error, value, schema: this } } ) )
-					}
-				}
-				
-				return value
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( Array.isArray( value ) )
+					for( const [ index, item ] of value.entries() )
+						yield* Item.issues_lazy( item, [ ...path, index ] )
+				else yield { message: 'Non array', path }
 			}
-			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
 				if( !Array.isArray( value ) ) return this.default
 				return value.map( item => Item.cast( item ) ) as typeof this.default

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -16,7 +16,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				if( Array.isArray( value ) )
 					for( const [ index, item ] of value.entries() )
 						yield* Item.issues_lazy( item, [ ...path, index ] )

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -16,11 +16,11 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				if( Array.isArray( value ) )
 					for( const [ index, item ] of value.entries() )
 						yield* Item.issues_lazy( item, [ ...path, index ] )
-				else yield { message: 'Non array', path }
+				else yield { message: 'Non array', path, value, schema: this }
 			}
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
 				if( !Array.isArray( value ) ) return this.default

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -12,10 +12,7 @@ namespace $ {
 				return '$mol_schema_list<' + $mol_key(Item) + '>'
 			}	
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/list/list.ts
+++ b/schema/list/list.ts
@@ -12,7 +12,7 @@ namespace $ {
 				return '$mol_schema_list<' + $mol_key(Item) + '>'
 			}	
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/maybe/maybe.test.ts
+++ b/schema/maybe/maybe.test.ts
@@ -25,7 +25,7 @@ namespace $.$$ {
 			$mol_assert_equal( null, Config.cast( 0 ) )
 			
 			$mol_assert_equal( 'foo', Config.guard( 'foo' ) )
-			$mol_assert_fail( ()=> Config.guard( 123 ), 'Wrong string' )
+			$mol_assert_fail( ()=> Config.guard( 123 ), 'Wrong type' )
 			
 		},
 		

--- a/schema/maybe/maybe.test.ts
+++ b/schema/maybe/maybe.test.ts
@@ -25,7 +25,7 @@ namespace $.$$ {
 			$mol_assert_equal( null, Config.cast( 0 ) )
 			
 			$mol_assert_equal( 'foo', Config.guard( 'foo' ) )
-			$mol_assert_fail( ()=> Config.guard( 123 ), 'Wrong type' )
+			$mol_assert_fail( ()=> Config.guard( 123 ), 'Wrong string' )
 			
 		},
 		

--- a/schema/maybe/maybe.ts
+++ b/schema/maybe/maybe.ts
@@ -12,9 +12,16 @@ namespace $ {
 				return '$mol_schema_maybe<' + $mol_key(Some) + '>'
 			}
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				if( value == null ) return value
-				return Some.guard( value )
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( value == null ) return
+				yield* Some.issues_lazy( value, path )
 			}
 			
 			static default = null as Some['default'] | null

--- a/schema/maybe/maybe.ts
+++ b/schema/maybe/maybe.ts
@@ -12,10 +12,7 @@ namespace $ {
 				return '$mol_schema_maybe<' + $mol_key(Some) + '>'
 			}
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/maybe/maybe.ts
+++ b/schema/maybe/maybe.ts
@@ -12,7 +12,7 @@ namespace $ {
 				return '$mol_schema_maybe<' + $mol_key(Some) + '>'
 			}
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/partial/partial.test.ts
+++ b/schema/partial/partial.test.ts
@@ -21,7 +21,7 @@ namespace $.$$ {
 				User.guard({ name: 'foo', age: undefined }),
 				// User.guard({ name: 'foo' }),
 			)
-			$mol_assert_fail( ()=> User.guard({ name: 'foo', age: 'bar' }), 'Wrong number' )
+			$mol_assert_fail( ()=> User.guard({ name: 'foo', age: 'bar' }), 'Wrong field' )
 			
 		},
 		

--- a/schema/partial/partial.test.ts
+++ b/schema/partial/partial.test.ts
@@ -21,7 +21,7 @@ namespace $.$$ {
 				User.guard({ name: 'foo', age: undefined }),
 				// User.guard({ name: 'foo' }),
 			)
-			$mol_assert_fail( ()=> User.guard({ name: 'foo', age: 'bar' }), 'Wrong field' )
+			$mol_assert_fail( ()=> User.guard({ name: 'foo', age: 'bar' }), 'Wrong number' )
 			
 		},
 		

--- a/schema/pattern/pattern.test.ts
+++ b/schema/pattern/pattern.test.ts
@@ -23,7 +23,7 @@ namespace $.$$ {
 			$mol_assert_equal( '', Email.cast( 123 ) )
 			
 			$mol_assert_equal( 'foo@bar', Email.guard( 'foo@bar' ) )
-			$mol_assert_fail( ()=> Email.guard( 'foo' ), 'Wrong pattern' )
+			$mol_assert_fail( ()=> Email.guard( 'foo' ), 'Wrong string' )
 			
 		},
 		

--- a/schema/pattern/pattern.test.ts
+++ b/schema/pattern/pattern.test.ts
@@ -23,7 +23,7 @@ namespace $.$$ {
 			$mol_assert_equal( '', Email.cast( 123 ) )
 			
 			$mol_assert_equal( 'foo@bar', Email.guard( 'foo@bar' ) )
-			$mol_assert_fail( ()=> Email.guard( 'foo' ), 'Wrong string' )
+			$mol_assert_fail( ()=> Email.guard( 'foo' ), 'Wrong pattern' )
 			
 		},
 		

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -9,10 +9,7 @@ namespace $ {
 				return '$mol_schema_pattern<' + $mol_key(Pattern) + '>'
 			}
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -9,9 +9,17 @@ namespace $ {
 				return '$mol_schema_pattern<' + $mol_key(Pattern) + '>'
 			}
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				if( Pattern.test( super.guard( value ) ) ) return value
-				return $mol_fail( new TypeError( 'Wrong string', { cause: { value, schema: this } } ) )
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				yield* super.issues_lazy( value, path )
+				if( Pattern.test( value as any ) ) return
+				yield { message: 'Wrong pattern', path }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -16,7 +16,7 @@ namespace $ {
 			) {
 				yield* super.issues_lazy( value, path )
 				if( Pattern.test( value as any ) ) return
-				yield { message: 'Wrong pattern', path }
+				yield { message: 'Wrong pattern', path, kind: "string" }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -13,7 +13,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				const { value: issue } = super.issues_lazy( value, path ).next()
 				if( issue ) {
 					yield issue

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -20,7 +20,7 @@ namespace $ {
 					return
 				}
 				if( Pattern.test( value as any ) ) return
-				yield { message: 'Wrong pattern', path }
+				yield { message: 'Wrong pattern', path, value, schema: this }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -20,7 +20,7 @@ namespace $ {
 					return
 				}
 				if( Pattern.test( value as any ) ) return
-				yield { message: 'Wrong pattern', path, kind: [ "string" ] }
+				yield { message: 'Wrong pattern', path }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -9,11 +9,11 @@ namespace $ {
 				return '$mol_schema_pattern<' + $mol_key(Pattern) + '>'
 			}
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				yield* super.issues_lazy( value, path )
 				if( Pattern.test( value as any ) ) return
 				yield { message: 'Wrong pattern', path, kind: "string" }

--- a/schema/pattern/pattern.ts
+++ b/schema/pattern/pattern.ts
@@ -14,9 +14,13 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
-				yield* super.issues_lazy( value, path )
+				const { value: issue } = super.issues_lazy( value, path ).next()
+				if( issue ) {
+					yield issue
+					return
+				}
 				if( Pattern.test( value as any ) ) return
-				yield { message: 'Wrong pattern', path, kind: "string" }
+				yield { message: 'Wrong pattern', path, kind: [ "string" ] }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/range/range.ts
+++ b/schema/range/range.ts
@@ -16,7 +16,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				if( typeof value !== 'number' && typeof value !== 'bigint' )
 					yield { message: 'Uncomparable type', path, value, schema: this }
 				else if(!( value <= Range[1] ))

--- a/schema/range/range.ts
+++ b/schema/range/range.ts
@@ -11,12 +11,21 @@ namespace $ {
 				if( this !== $mol_schema_range_ ) return super.toString()
 				return '$mol_schema_range<' + $mol_key(Range) + '>'
 			}	
-			
-			static guard< This extends typeof $mol_schema_any, Val >( this: This, value: Val ): Val & This['default'] {
-				if( typeof value !== 'number' && typeof value !== 'bigint' ) return $mol_fail( new TypeError( 'Uncomparable type', { cause: { value, schema: this } } ) )
-				if(!( value <= Range[1] )) return $mol_fail( new TypeError( 'Too large', { cause: { value, schema: this } } ) )
-				if(!( value >= Range[0] )) return $mol_fail( new TypeError( 'Too small', { cause: { value, schema: this } } ) )
-				return value
+
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Val
+			>(
+				this: This,
+				value: Val,
+				path: $mol_schema_issue_path = [],
+			) {
+				if( typeof value !== 'number' && typeof value !== 'bigint' )
+					yield { message: 'Uncomparable type', path }
+				else if(!( value <= Range[1] ))
+					yield { message: 'Too large', path }
+				else if(!( value >= Range[0] ))
+					yield { message: 'Too small', path }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: Value ): This['default'] {

--- a/schema/range/range.ts
+++ b/schema/range/range.ts
@@ -16,13 +16,13 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				if( typeof value !== 'number' && typeof value !== 'bigint' )
-					yield { message: 'Uncomparable type', path }
+					yield { message: 'Uncomparable type', path, value, schema: this }
 				else if(!( value <= Range[1] ))
-					yield { message: 'Too large', path }
+					yield { message: 'Too large', path, value, schema: this }
 				else if(!( value >= Range[0] ))
-					yield { message: 'Too small', path }
+					yield { message: 'Too small', path, value, schema: this }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: Value ): This['default'] {

--- a/schema/range/range.ts
+++ b/schema/range/range.ts
@@ -12,7 +12,7 @@ namespace $ {
 				return '$mol_schema_range<' + $mol_key(Range) + '>'
 			}	
 
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/range/range.ts
+++ b/schema/range/range.ts
@@ -12,12 +12,9 @@ namespace $ {
 				return '$mol_schema_range<' + $mol_key(Range) + '>'
 			}	
 
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Val
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
-				value: Val,
+				value: Value,
 				path: $mol_schema_issue_path = [],
 			) {
 				if( typeof value !== 'number' && typeof value !== 'bigint' )

--- a/schema/record/record.test.ts
+++ b/schema/record/record.test.ts
@@ -31,8 +31,8 @@ namespace $.$$ {
 			
 			$mol_assert_equal( { name: 'foo', age: 123 }, User.guard({ name: 'foo', age: 123 }) )
 			$mol_assert_equal( { name: 'foo', age: 123, salary: 777 }, User.guard({ name: 'foo', age: 123, salary: 777 }) )
-			$mol_assert_fail( ()=> User.guard( {} ), 'Wrong field' )
-			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar'} ), 'Wrong field' )
+			$mol_assert_fail( ()=> User.guard( {} ), 'Wrong string' )
+			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar'} ), 'Wrong number' )
 			
 		},
 		
@@ -60,7 +60,7 @@ namespace $.$$ {
 				{ name: 'foo', age: 123, space: 'bar' },
 				Admin.guard({ name: 'foo', age: 123, space: 'bar' }),
 			)
-			$mol_assert_fail( ()=> Admin.guard({ name: 'foo', age: 123 }), 'Wrong field' )
+			$mol_assert_fail( ()=> Admin.guard({ name: 'foo', age: 123 }), 'Wrong string' )
 			
 		},
 		

--- a/schema/record/record.test.ts
+++ b/schema/record/record.test.ts
@@ -31,8 +31,8 @@ namespace $.$$ {
 			
 			$mol_assert_equal( { name: 'foo', age: 123 }, User.guard({ name: 'foo', age: 123 }) )
 			$mol_assert_equal( { name: 'foo', age: 123, salary: 777 }, User.guard({ name: 'foo', age: 123, salary: 777 }) )
-			$mol_assert_fail( ()=> User.guard( {} ), 'Wrong string' )
-			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar' } ), 'Wrong number' )
+			$mol_assert_fail( ()=> User.guard( {} ), 'Wrong field' )
+			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar'} ), 'Wrong field' )
 			
 		},
 		
@@ -60,7 +60,7 @@ namespace $.$$ {
 				{ name: 'foo', age: 123, space: 'bar' },
 				Admin.guard({ name: 'foo', age: 123, space: 'bar' }),
 			)
-			$mol_assert_fail( ()=> Admin.guard({ name: 'foo', age: 123 }), 'Wrong string' )
+			$mol_assert_fail( ()=> Admin.guard({ name: 'foo', age: 123 }), 'Wrong field' )
 			
 		},
 		

--- a/schema/record/record.test.ts
+++ b/schema/record/record.test.ts
@@ -32,7 +32,7 @@ namespace $.$$ {
 			$mol_assert_equal( { name: 'foo', age: 123 }, User.guard({ name: 'foo', age: 123 }) )
 			$mol_assert_equal( { name: 'foo', age: 123, salary: 777 }, User.guard({ name: 'foo', age: 123, salary: 777 }) )
 			$mol_assert_fail( ()=> User.guard( {} ), 'Wrong string' )
-			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar'} ), 'Wrong number' )
+			$mol_assert_fail( ()=> User.guard( { name: 'foo', age: 'bar' } ), 'Wrong number' )
 			
 		},
 		

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -17,17 +17,10 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
-				try {
-					var proto = Object.getPrototypeOf( Object.getPrototypeOf( value ) )
-				} catch( error ) {
-					yield { message: 'Non record', path, error }
-					return
-				}
-				if ( proto )
+				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path }
 				else for( const field in Fields )
-					for( const i of Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] ) )
-						yield { ...i, kind: [ "field", ...i.kind ?? [] ] }
+					yield* Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] )
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -17,7 +17,7 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues<Value> {
-				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
+				if( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path, value, schema: this }
 				else {
 					const errors = []
@@ -29,12 +29,12 @@ namespace $ {
 							yield* schema.issues_lazy( value_, path_ )
 						} catch( error ) {
 							if( $mol_promise_like( error ) ) $mol_fail_hidden( error )
-							else errors.push(new Error("Wrong schema", { cause: { e: error, value: value_, path: path_, schema }  }) )
+							else errors.push(new Error( 'Wrong schema', { cause: { e: error, value: value_, path: path_, schema }  } ) )
 						}
 					}
 					if( errors.length === 0 ) return
 					else if( errors.length === 1 ) $mol_fail( errors[0] )
-					else $mol_fail( new AggregateError( errors, "Wrong schemas", { cause: { path, value, schema: this } }) )
+					else $mol_fail( new AggregateError( errors, 'Wrong schemas', { cause: { path, value, schema: this } } ) )
 				}
 			}
 			

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -16,7 +16,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path, value, schema: this }
 				else for( const field in Fields )

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -12,21 +12,18 @@ namespace $ {
 				return '$mol_schema_record<' + $mol_key(Fields) + '>'
 			}	
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				
-				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) ) {
-					return $mol_fail( new TypeError( 'Non record', { cause: { value, schema: this } } ) )
-				}
-			
-				for( const field in Fields ) {
-					try {
-						Fields[ field ].guard( ( value as any )[ field ] )
-					} catch( error ) {
-						return $mol_fail( new TypeError( 'Wrong field', { cause: { field, error, value, schema: this } } ) )
-					}
-				}
-				
-				return value
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				if (Object.getPrototypeOf(Object.getPrototypeOf(value)))
+					yield { message: 'Non record', path }
+				else for (const field in Fields)
+					yield* Fields[field].issues_lazy((value as any)[field], [...path, field])
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -17,11 +17,17 @@ namespace $ {
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
-				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
+				try {
+					var proto = Object.getPrototypeOf( Object.getPrototypeOf( value ) )
+				} catch( error ) {
+					yield { message: 'Non record', path, error }
+					return
+				}
+				if ( proto )
 					yield { message: 'Non record', path }
 				else for( const field in Fields )
 					for( const i of Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] ) )
-						yield {...i, kind: "field" }
+						yield { ...i, kind: [ "field", ...i.kind ?? [] ] }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -12,11 +12,11 @@ namespace $ {
 				return '$mol_schema_record<' + $mol_key(Fields) + '>'
 			}	
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path }
 				else for( const field in Fields )

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -19,8 +19,23 @@ namespace $ {
 			): $mol_schema_issues<Value> {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path, value, schema: this }
-				else for( const field in Fields )
-					yield* Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] )
+				else {
+					const errors = []
+					for( const field in Fields ) {
+						const schema = Fields[ field ]
+						const value_ = ( value as any )[ field ]
+						const path_ = [ ...path, field ]
+						try {
+							yield* schema.issues_lazy( value_, path_ )
+						} catch( error ) {
+							if( $mol_promise_like( error ) ) $mol_fail_hidden( error )
+							else errors.push(new Error("Wrong schema", { cause: { e: error, value: value_, path: path_, schema }  }) )
+						}
+					}
+					if( errors.length === 0 ) return
+					else if( errors.length === 1 ) $mol_fail( errors[0] )
+					else $mol_fail( new AggregateError( errors, "Wrong schemas", { cause: { path, value, schema: this } }) )
+				}
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -1,5 +1,5 @@
 namespace $ {
-	export let $mol_schema_record =  $mol_memo_key.func( function $mol_schema_record<
+	export let $mol_schema_record = $mol_memo_key.func( function $mol_schema_record<
 		Fields extends Record< string, typeof $mol_schema_any >
 	>( Fields: Fields ) {
 		
@@ -12,18 +12,15 @@ namespace $ {
 				return '$mol_schema_record<' + $mol_key(Fields) + '>'
 			}	
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			) {
-				if (Object.getPrototypeOf(Object.getPrototypeOf(value)))
+				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path }
-				else for (const field in Fields)
-					yield* Fields[field].issues_lazy((value as any)[field], [...path, field])
+				else for( const field in Fields )
+					yield* Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] )
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -18,7 +18,7 @@ namespace $ {
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues {
 				if ( !value || Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
-					yield { message: 'Non record', path }
+					yield { message: 'Non record', path, value, schema: this }
 				else for( const field in Fields )
 					yield* Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] )
 			}

--- a/schema/record/record.ts
+++ b/schema/record/record.ts
@@ -20,7 +20,8 @@ namespace $ {
 				if( Object.getPrototypeOf( Object.getPrototypeOf( value ) ) )
 					yield { message: 'Non record', path }
 				else for( const field in Fields )
-					yield* Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] )
+					for( const i of Fields[ field ].issues_lazy( ( value as any )[ field ], [ ...path, field ] ) )
+						yield {...i, kind: "field" }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -1,4 +1,10 @@
 namespace $ {
+
+	function* merge<T>(generators: Generator<T>[]) {
+		for (const g of generators)
+			yield* g
+	}
+
 	export let $mol_schema_some = $mol_memo_key.func( function $mol_schema_some<
 		Variants extends readonly( typeof $mol_schema_any )[]
 	>( Variants: Variants ) {
@@ -12,21 +18,25 @@ namespace $ {
 				return '$mol_schema_some<' + $mol_key(Variants) + '>'
 			}	
 			
-			static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-				
-				const errors = [] as unknown[]
-				for( const Variant of Variants ) {
-					
-					try {
-						return Variant.guard( value )
-					} catch( error ) {
-						errors.push( error )
-					}
-					
+			static override *issues_lazy<
+				This extends typeof $mol_schema_any,
+				Value
+			>(
+				this: This,
+				value: Value,
+				path: $mol_schema_issue_path = [],
+			) {
+				const issues = []
+				for (const Variant of Variants) {
+					const iter = Variant.issues_lazy(value, path)
+					const first = iter.next()
+					if (first.done) return
+					issues.push((function* () {
+						yield first.value
+						yield* iter
+					})())
 				}
-				
-				return $mol_fail( new AggregateError( errors, 'Wrong variant', { cause: { value, schema: this } } ) )
-				
+				yield { message: 'Wrong variant', path, issues: merge(issues) }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -24,7 +24,8 @@ namespace $ {
 				path: $mol_schema_issue_path = [],
 			): $mol_schema_issues<Value> {
 				const issues = []
-				for( const Variant of Variants ) {
+				const errors = []
+				for( const Variant of Variants ) try {
 					const iter = Variant.issues_lazy( value, path )
 					const first = iter.next()
 					if( first.done ) return
@@ -32,8 +33,20 @@ namespace $ {
 						yield first.value
 						yield* iter
 					})())
+				} catch( error ) {
+					if( $mol_promise_like( error ) ) $mol_fail_hidden( error )
+					else errors.push( error )
 				}
-				yield { message: 'Wrong variant', path, issues: merge( issues ), value, schema: this }
+				if( errors.length === 0 )
+					yield { message: 'Wrong variant', path, issues: merge( issues ), value, schema: this }
+				else {
+					const cause = {
+						path, value, schema: this,
+						issues: issues.map( i => Array.from( i, $mol_schema_issue_eager ) ),
+					}
+					if( errors.length === 1 ) $mol_fail( new Error( "Wrong schema", { cause: { error: errors[0], ...cause } } ) )
+					else $mol_fail( new AggregateError( errors, 'Wrong schemas', { cause } ) )
+				}
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -25,18 +25,22 @@ namespace $ {
 			): $mol_schema_issues<Value> {
 				const issues = []
 				const errors = []
-				for( const Variant of Variants ) try {
-					const iter = Variant.issues_lazy( value, path )
-					const first = iter.next()
-					if( first.done ) return
-					issues.push((function* () {
-						yield first.value
-						yield* iter
-					})())
-				} catch( error ) {
-					if( $mol_promise_like( error ) ) $mol_fail_hidden( error )
-					else errors.push( error )
+				
+				for( const Variant of Variants ) {
+					try {
+						const iter = Variant.issues_lazy( value, path )
+						const first = iter.next()
+						if( first.done ) return
+						issues.push( (function* () {
+							yield first.value
+							yield* iter
+						})() )
+					} catch( error ) {
+						if( $mol_promise_like( error ) ) $mol_fail_hidden( error )
+						else errors.push( error )
+					}
 				}
+				
 				if( errors.length === 0 )
 					yield { message: 'Wrong variant', path, issues: merge( issues ), value, schema: this }
 				else {
@@ -44,7 +48,7 @@ namespace $ {
 						path, value, schema: this,
 						issues: issues.map( i => Array.from( i, $mol_schema_issue_eager ) ),
 					}
-					if( errors.length === 1 ) $mol_fail( new Error( "Wrong schema", { cause: { error: errors[0], ...cause } } ) )
+					if( errors.length === 1 ) $mol_fail( new Error( 'Wrong schema', { cause: { error: errors[0], ...cause } } ) )
 					else $mol_fail( new AggregateError( errors, 'Wrong schemas', { cause } ) )
 				}
 			}

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -1,8 +1,8 @@
 namespace $ {
 
-	function* merge<T>( generators: Generator<T>[] ) {
-		for( const g of generators )
-			yield* g
+	function* merge<T>( iterable: Iterable<T>[] ) {
+		for( const i of iterable )
+			yield* i
 	}
 
 	export let $mol_schema_some = $mol_memo_key.func( function $mol_schema_some<

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -18,7 +18,7 @@ namespace $ {
 				return '$mol_schema_some<' + $mol_key(Variants) + '>'
 			}	
 			
-			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+			static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -1,7 +1,7 @@
 namespace $ {
 
-	function* merge<T>(generators: Generator<T>[]) {
-		for (const g of generators)
+	function* merge<T>( generators: Generator<T>[] ) {
+		for( const g of generators )
 			yield* g
 	}
 
@@ -18,33 +18,27 @@ namespace $ {
 				return '$mol_schema_some<' + $mol_key(Variants) + '>'
 			}	
 			
-			static override *issues_lazy<
-				This extends typeof $mol_schema_any,
-				Value
-			>(
+			static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
 			) {
 				const issues = []
-				for (const Variant of Variants) {
-					const iter = Variant.issues_lazy(value, path)
+				for( const Variant of Variants ) {
+					const iter = Variant.issues_lazy( value, path )
 					const first = iter.next()
-					if (first.done) return
+					if( first.done ) return
 					issues.push((function* () {
 						yield first.value
 						yield* iter
 					})())
 				}
-				yield { message: 'Wrong variant', path, issues: merge(issues) }
+				yield { message: 'Wrong variant', path, issues: merge( issues ) }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {
-				try {
-					return this.guard( value )
-				} catch ( error ) {
-					return Variants[0].cast( value )
-				}
+				if( this.issues_lazy( value ).next().done ) return value
+				return Variants[0].cast( value )
 			}
 			
 			static default = Variants[0].default as Variants[number]['default']

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -22,7 +22,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			) {
+			): $mol_schema_issues {
 				const issues = []
 				for( const Variant of Variants ) {
 					const iter = Variant.issues_lazy( value, path )
@@ -33,7 +33,7 @@ namespace $ {
 						yield* iter
 					})())
 				}
-				yield { message: 'Wrong variant', path, issues: merge( issues ) }
+				yield { message: 'Wrong variant', path, issues: merge( issues ), value, schema: this }
 			}
 			
 			static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/some/some.ts
+++ b/schema/some/some.ts
@@ -22,7 +22,7 @@ namespace $ {
 				this: This,
 				value: Value,
 				path: $mol_schema_issue_path = [],
-			): $mol_schema_issues {
+			): $mol_schema_issues<Value> {
 				const issues = []
 				for( const Variant of Variants ) {
 					const iter = Variant.issues_lazy( value, path )

--- a/schema/string/string.test.ts
+++ b/schema/string/string.test.ts
@@ -12,7 +12,7 @@ namespace $.$$ {
 			$mol_assert_equal( '', $mol_schema_string.cast( 123 ) )
 			
 			$mol_assert_equal( 'foo', $mol_schema_string.guard( 'foo' ) )
-			$mol_assert_fail( ()=> $mol_schema_string.guard( 123 ), 'Wrong string' )
+			$mol_assert_fail( ()=> $mol_schema_string.guard( 123 ), 'Wrong type' )
 			
 		},
 		

--- a/schema/string/string.test.ts
+++ b/schema/string/string.test.ts
@@ -12,7 +12,7 @@ namespace $.$$ {
 			$mol_assert_equal( '', $mol_schema_string.cast( 123 ) )
 			
 			$mol_assert_equal( 'foo', $mol_schema_string.guard( 'foo' ) )
-			$mol_assert_fail( ()=> $mol_schema_string.guard( 123 ), 'Wrong type' )
+			$mol_assert_fail( ()=> $mol_schema_string.guard( 123 ), 'Wrong string' )
 			
 		},
 		

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'string' ) return
-			yield { message: 'Wrong string', path: path, kind: [ 'type' ] }
+			yield { message: 'Wrong string', path }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -1,11 +1,11 @@
 namespace $ {
 	export class $mol_schema_string extends $mol_schema_any {
 		
-		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
+		static *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		) {
+		): $mol_schema_issues {
 			if( typeof value === 'string' ) return
 			yield { message: 'Wrong string', path: path, kind: "type" }
 		}

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -5,7 +5,7 @@ namespace $ {
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],
-		): $mol_schema_issues {
+		): $mol_schema_issues<Value> {
 			if( typeof value === 'string' ) return
 			yield { message: 'Wrong string', path, value, schema: this }
 		}

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -1,9 +1,13 @@
 namespace $ {
 	export class $mol_schema_string extends $mol_schema_any {
 		
-		static guard< This extends typeof $mol_schema_any, Value >( this: This, value: Value ): Value & This['default'] {
-			if( typeof value === 'string' ) return value
-			return $mol_fail( new TypeError( 'Wrong type', { cause: { value, schema: this } } ) )
+		static override *issues_lazy<This extends typeof $mol_schema_any, Value>(
+			this: This,
+			value: Value,
+			path: $mol_schema_issue_path = [],
+		) {
+			if( typeof value === 'string' ) return
+			yield { message: 'Wrong string', path: path }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -1,7 +1,7 @@
 namespace $ {
 	export class $mol_schema_string extends $mol_schema_any {
 		
-		static override *issues_lazy<This extends typeof $mol_schema_any, Value>(
+		static override *issues_lazy< This extends typeof $mol_schema_any, Value >(
 			this: This,
 			value: Value,
 			path: $mol_schema_issue_path = [],

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'string' ) return
-			yield { message: 'Wrong string', path }
+			yield { message: 'Wrong string', path, value, schema: this }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		): $mol_schema_issues {
 			if( typeof value === 'string' ) return
-			yield { message: 'Wrong string', path: path, kind: "type" }
+			yield { message: 'Wrong string', path: path, kind: [ 'type' ] }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {

--- a/schema/string/string.ts
+++ b/schema/string/string.ts
@@ -7,7 +7,7 @@ namespace $ {
 			path: $mol_schema_issue_path = [],
 		) {
 			if( typeof value === 'string' ) return
-			yield { message: 'Wrong string', path: path }
+			yield { message: 'Wrong string', path: path, kind: "type" }
 		}
 		
 		static cast< This extends typeof $mol_schema_any >( this: This, value: unknown ): This['default'] {


### PR DESCRIPTION

- Переписан механизм валидации схем: вместо выбрасывания исключений в `guard` схемы теперь генерируют проблемы через `issues_lazy` / `issues`.
- `check` больше не полагается на try/catch, `guard` бросает `TypeError` с полным набором полей issue в `cause`.
- Во всех схемах (bigint, boolean, dict, enum, every, float, instance, integer, lazy, list, maybe, pattern, range, record, some, string) сообщения ошибок стали конкретными (`Wrong float`, `Wrong number`, `Wrong string`, `Wrong pattern` и т.д.).
- Добавлен адаптер Standard Schema (`~standard`).