### PR TITLE
rest: close ws socket on end

### DIFF
--- a/rest/server/server.node.test.ts
+++ b/rest/server/server.node.test.ts
@@ -1,0 +1,70 @@
+namespace $.$$ {
+	$mol_test({
+
+		async 'ws socket is closed by server after peer half close'( $ ) {
+
+			const ports = [] as $mol_rest_port[]
+
+			const server = $mol_rest_server.make({
+				$,
+				root: ()=> $mol_rest_resource.make({
+					OPEN: ( msg: $mol_rest_message )=> {
+						ports.push( msg.port )
+						return 'test'
+					},
+				}),
+			})
+
+			const http = server.http_server()
+
+			try {
+
+				if( !http.listening ) await new Promise( done => http.once( 'listening', done ) )
+				const port = ( http.address() as { port: number } ).port
+
+				const socket = $node.net.connect( port, '127.0.0.1' )
+
+				try {
+
+					await new Promise( done => socket.once( 'connect', done ) )
+
+					socket.write(
+						'GET / HTTP/1.1\r\n' +
+						'Host: localhost\r\n' +
+						'Upgrade: websocket\r\n' +
+						'Connection: Upgrade\r\n' +
+						`Sec-WebSocket-Key: ${ $mol_base64_encode( new Uint8Array( 16 ) ) }\r\n` +
+						'Sec-WebSocket-Version: 13\r\n' +
+						'Sec-WebSocket-Protocol: test\r\n' +
+						'\r\n'
+					)
+
+					const handshake = await new Promise< string >(
+						done => socket.once( 'data', chunk => done( String( chunk ) ) )
+					)
+					$mol_assert_equal( handshake.startsWith( 'HTTP/1.1 101' ), true )
+					$mol_assert_equal( ports.length, 1 )
+
+					const accepted = ( ports[0] as $mol_rest_port_ws_node ).socket
+
+					socket.end()
+
+					for( let i = 0; i < 30; ++i ) {
+						if( accepted.writableEnded ) break
+						await new Promise( done => setTimeout( done, 10 ) )
+					}
+
+					$mol_assert_equal( accepted.writableEnded, true )
+
+				} finally {
+					socket.destroy()
+				}
+
+			} finally {
+				http.close()
+			}
+
+		},
+
+	})
+}

--- a/rest/server/server.node.ts
+++ b/rest/server/server.node.ts
@@ -169,7 +169,7 @@ namespace $ {
 				
 			} )
 			
-			socket.on( 'end', onclose )
+			socket.on( 'end', ()=> { onclose(); socket.end() } )
 			socket.on( 'error', onclose )
 			
 			socket.on( 'data', ( chunk: Buffer< ArrayBuffer > )=> this.ws_income( chunk, upgrade, socket ) )


### PR DESCRIPTION
Upgraded websocket sockets are never closed on the server side.

In `$mol_rest_server.ws_upgrade` the `end` handler only runs the app-level `CLOSE`:

```js
socket.on( "end", onclose )
socket.on( "error", onclose )
```

`onclose` removes the port from the yard slaves but never touches the socket itself — no `end()`, no `destroy()`. On an upgraded connection Node hands the raw socket to the application and stops managing it, so the half-open state persists until the application closes its own side. It never does, and the socket stays in `CLOSE_WAIT` for the lifetime of the process.

### Impact

A live `$giper_baza` node sitting behind a reverse proxy accumulated **1676 sockets in `CLOSE_WAIT`** over 7 hours of uptime — all on the listening port, all from the proxy — growing at roughly 4 per minute. Over a day that is around 6000 leaked descriptors.

A second, quieter effect: a client that politely half-closes never receives `close`, because the server never sends its FIN. A plain test client written against it hangs forever.

Plain HTTP is unaffected — 40 sequential GETs leave the descriptor count unchanged. Only the upgrade path leaks.

### Reproduction

Minimal server mirroring the current handler, 20 upgrades each closed by the client:

```
without the fix: handshakes=20  CLOSE_WAIT=20
with the fix:    handshakes=20  CLOSE_WAIT=0
```

### Fix

Answer the peer FIN with our own once the app-level `CLOSE` has run.