### PR TITLE
build/server: sort directory listing by name

### DIFF
--- a/build/server/server.node.ts
+++ b/build/server/server.node.ts
@@ -232,7 +232,8 @@ namespace $ {
 				<link href="/_logo.png" rel="icon" />
 				<a href="..">&#x1F4C1; ..</a>
 				` + files
-				.sort($mol_compare_text((item) => item.type))
+				.sort( $mol_compare_text( item => item.name ) )
+				.sort( $mol_compare_text( item => item.type ) )
 				.map( file => `<a href="${file.name}">${file.type === 'dir' ? '&#x1F4C1;' : '&#128196;'} ${file.name}</a>` )
 				.join( '\n' )
 			


### PR DESCRIPTION
Directory listing in the dev server was sorted by type only, so entries within each type kept raw readdir order, and packs from *.meta.tree were appended at the end. Now entries are sorted by name (case-insensitive, numeric-aware) and then by type, so directories come first, each group alphabetically.