### PR TITLE
$mol_view_tree2_to_dts: assert $$ override names against view.tree props

### DIFF
--- a/type/case/case.test.ts
+++ b/type/case/case.test.ts
@@ -222,41 +222,4 @@ namespace $ {
 
 	>
 
-
-	type fold1 = $mol_type_assert<
-
-		$mol_type_case_fold<
-			'foo_bar_wee'
-		>,
-		'foobarwee'
-
-	>
-
-	type fold2 = $mol_type_assert<
-
-		$mol_type_case_fold<
-			'fooBarWee'
-		>,
-		'foobarwee'
-
-	>
-
-	type fold3 = $mol_type_assert<
-
-		$mol_type_case_fold<
-			'Foo_bar_wee'
-		>,
-		'Foobarwee'
-
-	>
-
-	type fold4 = $mol_type_assert<
-
-		$mol_type_case_fold<
-			'foo_bar' | 'Foo_bar'
-		>,
-		'foobar' | 'Foobar'
-
-	>
-
 }

--- a/type/case/case.test.ts
+++ b/type/case/case.test.ts
@@ -222,4 +222,41 @@ namespace $ {
 
 	>
 
+
+	type fold1 = $mol_type_assert<
+
+		$mol_type_case_fold<
+			'foo_bar_wee'
+		>,
+		'foobarwee'
+
+	>
+
+	type fold2 = $mol_type_assert<
+
+		$mol_type_case_fold<
+			'fooBarWee'
+		>,
+		'foobarwee'
+
+	>
+
+	type fold3 = $mol_type_assert<
+
+		$mol_type_case_fold<
+			'Foo_bar_wee'
+		>,
+		'Foobarwee'
+
+	>
+
+	type fold4 = $mol_type_assert<
+
+		$mol_type_case_fold<
+			'foo_bar' | 'Foo_bar'
+		>,
+		'foobar' | 'Foobar'
+
+	>
+
 }

--- a/type/case/case.ts
+++ b/type/case/case.ts
@@ -182,21 +182,11 @@ namespace $ {
 	export type $mol_type_case_scream_parse< String extends string > =
 		$mol_type_case_cobra_parse< String >
 
-
 	type fold_tail< String extends string > =
 		String extends `${ infer Left }_${ infer Right }`
 		? `${ Left }${ fold_tail< Right > }`
 		: String
 
-	/**
-	 * Fold string to compare names regardless of case style. First char is kept as is.
-	 *
-	 * 	// 'foobarwee'
-	 * 	$mol_type_case_fold< 'foo_bar_wee' >
-	 * 	$mol_type_case_fold< 'fooBarWee' >
-	 * 	// 'Foobarwee'
-	 * 	$mol_type_case_fold< 'Foo_bar_wee' >
-	 */
 	export type $mol_type_case_fold< String extends string > =
 		String extends `${ infer Head }${ infer Tail }`
 		? `${ Head }${ Lowercase< fold_tail< Tail > > }`

--- a/type/case/case.ts
+++ b/type/case/case.ts
@@ -182,4 +182,24 @@ namespace $ {
 	export type $mol_type_case_scream_parse< String extends string > =
 		$mol_type_case_cobra_parse< String >
 
+
+	type fold_tail< String extends string > =
+		String extends `${ infer Left }_${ infer Right }`
+		? `${ Left }${ fold_tail< Right > }`
+		: String
+
+	/**
+	 * Fold string to compare names regardless of case style. First char is kept as is.
+	 *
+	 * 	// 'foobarwee'
+	 * 	$mol_type_case_fold< 'foo_bar_wee' >
+	 * 	$mol_type_case_fold< 'fooBarWee' >
+	 * 	// 'Foobarwee'
+	 * 	$mol_type_case_fold< 'Foo_bar_wee' >
+	 */
+	export type $mol_type_case_fold< String extends string > =
+		String extends `${ infer Head }${ infer Tail }`
+		? `${ Head }${ Lowercase< fold_tail< Tail > > }`
+		: String
+
 }

--- a/view/tree2/to/dts/dts.test.ts
+++ b/view/tree2/to/dts/dts.test.ts
@@ -9,11 +9,25 @@ namespace $ {
 				'test.view.tree',
 			)
 
-			const dts = $.$mol_tree2_text_to_string( $.$mol_view_tree2_to_dts( tree ) )
-
-			$mol_assert_equal( 
-				`$mol_view_override_mismatch< $mol_view_tree2_to_dts_test_foo, '$mol_view_tree2_to_dts_test_foo' >`
-			 )
+			$mol_assert_equal(
+				$.$mol_tree2_text_to_string( $.$mol_view_tree2_to_dts( tree ) ),
+				[
+					'declare namespace $ {',
+					'',
+					'\texport class $mol_view_tree2_to_dts_test_foo extends $mol_view_tree2_to_dts_test_base {',
+					'\t\tbar( ): string',
+					'\t}',
+					'\t',
+					'\ttype $mol_view_tree2_to_dts_test_foo__override_1 = $mol_type_enforce<',
+					'\t\t$mol_view_override_mismatch< $mol_view_tree2_to_dts_test_foo, \'$mol_view_tree2_to_dts_test_foo\' >',
+					'\t\t,',
+					'\t\t\'Override differs from view.tree prop only by case\'',
+					'\t>',
+					'\t',
+					'}',
+					'',
+				].join( '\n' ),
+			)
 
 		},
 

--- a/view/tree2/to/dts/dts.test.ts
+++ b/view/tree2/to/dts/dts.test.ts
@@ -1,0 +1,22 @@
+namespace $ {
+
+	$mol_test({
+
+		'override mismatch assert for every class'( $ ) {
+
+			const tree = $.$mol_tree2_from_string(
+				'$mol_view_tree2_to_dts_test_foo $mol_view_tree2_to_dts_test_base\n\tbar \\\n',
+				'test.view.tree',
+			)
+
+			const dts = $.$mol_tree2_text_to_string( $.$mol_view_tree2_to_dts( tree ) )
+
+			$mol_assert_ok( dts.includes(
+				`$mol_view_override_mismatch< $mol_view_tree2_to_dts_test_foo, '$mol_view_tree2_to_dts_test_foo' >`
+			) )
+
+		},
+
+	})
+
+}

--- a/view/tree2/to/dts/dts.test.ts
+++ b/view/tree2/to/dts/dts.test.ts
@@ -11,9 +11,9 @@ namespace $ {
 
 			const dts = $.$mol_tree2_text_to_string( $.$mol_view_tree2_to_dts( tree ) )
 
-			$mol_assert_ok( dts.includes(
+			$mol_assert_equal( 
 				`$mol_view_override_mismatch< $mol_view_tree2_to_dts_test_foo, '$mol_view_tree2_to_dts_test_foo' >`
-			) )
+			 )
 
 		},
 

--- a/view/tree2/to/dts/dts.ts
+++ b/view/tree2/to/dts/dts.ts
@@ -369,8 +369,15 @@ namespace $ {
 				... aliases,
 				klass.data( '}' ),
 				descr.data(''),
+				type_enforce.call(
+					this,
+					klass.data( `${ klass.type }__override_${ ++assert_count }` ),
+					[ klass.data( `$mol_view_override_mismatch< ${ klass.type }, '${ klass.type }' >` ) ],
+					[ klass.data( `'Override differs from view.tree prop only by case'` ) ],
+				),
+				descr.data(''),
 			)
-			
+
 		}
 
 		return descr.list([

--- a/view/tree2/to/dts/dts.ts
+++ b/view/tree2/to/dts/dts.ts
@@ -377,7 +377,7 @@ namespace $ {
 				),
 				descr.data(''),
 			)
-
+			
 		}
 
 		return descr.list([

--- a/view/view/view.tsx
+++ b/view/view/view.tsx
@@ -548,11 +548,6 @@ namespace $ {
 			: never
 		: never
 
-	/**
-	 * Props of `$$` override of view class `Name` which differ from `Base` props only by case.
-	 * View tree generates this assert for every class, so `exchangeResult()` in `.view.ts`
-	 * fails type check when `.view.tree` has `exchange_result`.
-	 */
 	export type $mol_view_override_mismatch< Base, Name extends string > =
 		keyof {
 			[

--- a/view/view/view.tsx
+++ b/view/view/view.tsx
@@ -541,4 +541,24 @@ namespace $ {
 
 	export type $mol_view_all = $mol_type_pick< $ , typeof $mol_view >
 
+	type override_of< Name extends string > =
+		Name extends keyof typeof $$
+		? ( typeof $$ )[ Name ] extends abstract new ( ... args: any ) => infer Over
+			? Over
+			: never
+		: never
+
+	/**
+	 * Props of `$$` override of view class `Name` which differ from `Base` props only by case.
+	 * View tree generates this assert for every class, so `exchangeResult()` in `.view.ts`
+	 * fails type check when `.view.tree` has `exchange_result`.
+	 */
+	export type $mol_view_override_mismatch< Base, Name extends string > =
+		keyof {
+			[
+				Key in Exclude< keyof override_of< Name >, keyof Base > & string
+				as $mol_type_case_fold< Key > extends $mol_type_case_fold< keyof Base & string > ? Key : never
+			]: Key
+		}
+
 }


### PR DESCRIPTION
## Problem

A method in `.view.ts` named like a `.view.tree` prop but in another case is silently a new method:

```tree
$my_app $mol_page
	title <= exchange_result \tree default
```

```ts
namespace $.$$ {
	export class $my_app extends $.$my_app {
		exchangeResult() { return 'from ts' }
	}
}
```

Build, audit and node tests are green, the screen shows `tree default`, the console is empty. Nothing points at the name. `override` would catch it with TS4117, but nobody writes `override` in every `.view.ts`.

## Solution

`$mol_view_tree2_to_dts` emits one more type assert per class into the generated `.d.ts`:

```ts
type $my_app__override_1 = $mol_type_enforce<
	$mol_view_override_mismatch< $my_app, '$my_app' >
	,
	'Override differs from view.tree prop only by case'
>
```

- `$mol_view_override_mismatch< Base, Name >` takes the `$$` class by name, keeps its props which are absent in `Base`, and returns those which differ from a `Base` prop only by case. No `$$` override gives `never`.
- `$mol_type_case_fold` folds a name for comparison: first char as is, the rest lowercased without underscores. So `exchange_result`, `exchangeResult` and `Exchange_result` collide, while `Title` and `title` stay a valid pair of a sub view and a value.
- The assert is types only, the bundle does not change.

The audit then says:

```
app.view.tree.d.ts(125,3): error TS2344: Type '"exchangeResult" | "exchange_rate"' does not satisfy the constraint '"Override differs from view.tree prop only by case"'.
```

A genuinely new method, `total()` for example, passes. `mol/page` and `mol/app/demo` audits stay green; `mol/app/demo` build takes 15 s and 1.87 GB peak RSS against 13 s and 1.80 GB before.

## Tests

- `type/case/case.test.ts`: `$mol_type_case_fold` on snake, camel, Cobra and a union.
- `view/tree2/to/dts/dts.test.ts`: the assert is generated for a class.

`mol/type/case`, `mol/view/tree2/to/dts`, `mol/page` and `mol/app/demo` audits and node tests pass.
